### PR TITLE
Added new configuration option to colorize sent messages depending on the current and previous states of job.

### DIFF
--- a/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
+++ b/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
@@ -141,6 +141,7 @@ public class IrcPublisher extends IMPublisher {
         
         private static final String PREFIX = "irc_publisher.";
 	    public static final String PARAMETERNAME_USE_NOTICE = PREFIX + "useNotice";
+	    public static final String PARAMETERNAME_USE_COLORS = PREFIX + "useColors";
 	    public static final String PARAMETERNAME_NICKSERV_PASSWORD = PREFIX + "nickServPassword";
 	    
 	    public static final String[] CHARSETS;
@@ -198,7 +199,9 @@ public class IrcPublisher extends IMPublisher {
         private boolean useNotice;
         
         private String charset;
-        
+
+        private boolean useColors;
+
         DescriptorImpl() {
             super(IrcPublisher.class);
             load();
@@ -270,9 +273,11 @@ public class IrcPublisher extends IMPublisher {
                 this.hudsonLogin = req.getParameter(getParamNames().getJenkinsLogin());
                 
                 this.useNotice = "on".equals(req.getParameter(PARAMETERNAME_USE_NOTICE));
-                
+
                 this.charset = req.getParameter("irc_publisher.charset");
-                
+
+                this.useColors = "on".equals(req.getParameter(PARAMETERNAME_USE_COLORS));
+
                 // try to establish the connection
                 try {
                 	IRCConnectionProvider.setDesc(this);
@@ -477,6 +482,13 @@ public class IrcPublisher extends IMPublisher {
 		 */
 		public boolean isUseNotice() {
 		    return this.useNotice;
+		}
+
+		/**
+		 * Specifies if the bot should send message with colors.
+		 */
+		public boolean isUseColors() {
+		    return this.useColors;
 		}
 		
 		public String getCharset() {

--- a/src/main/java/hudson/plugins/ircbot/v2/IRCColor.java
+++ b/src/main/java/hudson/plugins/ircbot/v2/IRCColor.java
@@ -1,0 +1,46 @@
+package hudson.plugins.ircbot.v2;
+
+import org.pircbotx.Colors;
+
+/**
+ * Simple support for IRC colors.
+ * 
+ * @author syl20bnr
+ */
+public class IRCColor {
+
+    private final String message;
+
+    public IRCColor(String message) {
+        this.message = message;
+    }
+
+    public String colorize(){
+        String color = Colors.DARK_GRAY;
+        if(this.message.startsWith("Starting")){
+            if (this.message.contains("FAIL")){
+                color = Colors.BROWN;
+            }
+            else if (this.message.contains("FIXED")){
+                color = Colors.OLIVE;
+            }
+            else{
+                color = Colors.DARK_GREEN;
+            }
+        }
+        else if(this.message.contains("FIXED")){
+           color = Colors.REVERSE + Colors.BOLD + Colors.GREEN;
+        }
+        else if(this.message.contains("SUCCESS")){
+           color = Colors.BOLD + Colors.GREEN;
+        }
+        else if(this.message.contains("FAILURE")){
+           color = Colors.REVERSE + Colors.BOLD + Colors.RED;
+        }
+        else if(this.message.contains("STILL FAILING")){
+           color = Colors.BOLD + Colors.RED;
+        }
+        return color + this.message;
+    }
+
+}

--- a/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
+++ b/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
@@ -267,6 +267,10 @@ public class IRCConnection implements IMConnection, JoinListener, InviteListener
             if (this.descriptor.isUseNotice()) {
                 this.pircConnection.sendNotice(channel, line);
             } else {
+                if (this.descriptor.isUseColors()){
+                    IRCColor cline = new IRCColor(line);
+                    line = cline.colorize();
+                }
                 this.pircConnection.sendMessage(channel, line);
             }
         }

--- a/src/main/resources/hudson/plugins/ircbot/IrcPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/ircbot/IrcPublisher/global.jelly
@@ -76,6 +76,9 @@
         <f:entry title="Use /notice command" description="Use /notice command instead of /msg (default in ircbot &lt;= 2.0)">
           <f:checkbox name="${descriptor.PARAMETERNAME_USE_NOTICE}" checked="${descriptor.useNotice}"/>
         </f:entry>
+        <f:entry title="Use colors" description="If checked, the bot will send colorized messages depending on the current and previous states of a job." help="/plugin/ircbot/help-globalConfigUseColors.html">
+          <f:checkbox name="${descriptor.PARAMETERNAME_USE_COLORS}" checked="${descriptor.useColors}"/>
+        </f:entry>
         
     </f:advanced>
    </f:optionalBlock>

--- a/src/main/webapp/help-globalConfigUseColors.html
+++ b/src/main/webapp/help-globalConfigUseColors.html
@@ -1,0 +1,25 @@
+<div>
+  <p>
+    Checking this box allows the bot to send colorized messages depending on the
+    current and previous states of a job.
+
+    The bot tries to send <font color="green">green messages</font> for successful jobs
+    and <font color="red">red messages</font> for failures <em> but this may not be right
+    if your IRC client has defined a custom theme of colors.</em>
+  </p>
+  <p>
+    Here are the rules for coloring messages:
+    <ul>
+        <li>Starting previously successful job: <font color="green">green</font></li>
+        <li>Starting previously fixed job: <font color="olive">olive</font></li>
+        <li>Starting previously failed job: <font color="red">red</font></li>
+        <li>First successful build (fixed job): <font color="black" style="background-color: green"><strong>green background</strong></font></li>
+        <li>First failure: <font color="black" style="background-color: red"><strong>red background</strong></font></li>
+        <li>Still successful job: <font color="green"><strong>bold green</strong></font></li>
+        <li>Still failing job: <font color="red"><strong>bold red</strong></font></li>
+        <li>Default message: <font color="darkgray"><strong>bold gray</strong></font></li>
+    </ul> 
+
+    There is no support for colorblind theme for now.
+  </p>
+</div>


### PR DESCRIPTION
```
Checking this box allows the bot to send colorized messages depending on the
current and previous states of a job.

The bot tries to send green messages for successful jobs
and red messages for failures but this may not be right
if your IRC client has defined a custom theme of colors.

Here are the rules for coloring messages:

    Starting previously successful job: green
    Starting previously fixed job: olive
    Starting previously failed job: red
    First successful build (fixed job): green background
    First failure: red background
    Still successful job: bold green
    Still failing job: bold red
    Default message: bold gray

There is no support for colorblind theme for now.
```
