### PR TITLE
Add option to trust all SSL certificates

### DIFF
--- a/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
+++ b/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
@@ -167,6 +167,8 @@ public class IrcPublisher extends IMPublisher {
         Integer port = 194;
         
         private boolean ssl;
+
+        private boolean sslTrustAllCertificates;
         
         private String login = "PircBotx";
 
@@ -271,6 +273,7 @@ public class IrcPublisher extends IMPublisher {
                             "irc_publisher.port");
                 }
                 this.ssl = "on".equals(req.getParameter("irc_publisher.ssl"));
+				this.sslTrustAllCertificates = "on".equals(req.getParameter("irc_publisher.ssl_trust_all_certificates"));
                 this.commandPrefix = req.getParameter("irc_publisher.commandPrefix");
                 this.commandPrefix = Util.fixEmptyAndTrim(commandPrefix);
                 
@@ -461,6 +464,10 @@ public class IrcPublisher extends IMPublisher {
         public boolean isSsl() {
             return this.ssl;
         }
+
+		public boolean trustAllCertificates() {
+			return this.sslTrustAllCertificates;
+		}
 
         //@Override
         public boolean isEnabled() {

--- a/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
+++ b/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
@@ -31,6 +31,7 @@ import javax.net.ssl.SSLSocketFactory;
 
 import org.pircbotx.Channel;
 import org.pircbotx.PircBotX;
+import org.pircbotx.UtilSSLSocketFactory;
 import org.pircbotx.exception.IrcException;
 import org.pircbotx.exception.NickAlreadyInUseException;
 
@@ -110,9 +111,12 @@ public class IRCConnection implements IMConnection, JoinListener, InviteListener
 			
 			final SocketFactory sf;
 			if (this.descriptor.isSsl()) {
-			    sf = SSLSocketFactory.getDefault();
+				if (this.descriptor.trustAllCertificates())
+					sf = new UtilSSLSocketFactory().trustAllCertificates();
+				else
+					sf = SSLSocketFactory.getDefault();
 			} else {
-			    sf = SocketFactory.getDefault();
+				sf = SocketFactory.getDefault();
 			}
 			
 		    this.pircConnection.connect(this.descriptor.getHost(), this.descriptor.getPort(), password, sf);

--- a/src/main/resources/hudson/plugins/ircbot/IrcPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/ircbot/IrcPublisher/global.jelly
@@ -63,6 +63,10 @@
           help="/plugin/ircbot/help-globalConfigCommandPrefix.html">
           <f:textbox name="irc_publisher.commandPrefix" value="${descriptor.getCommandPrefix()}" />
         </f:entry>
+
+        <f:entry title="Trust all SSL certificates" description="Ignore invalid (e.g. self-signed) SSL certificates">
+              <f:checkbox name="irc_publisher.ssl_trust_all_certificates" checked="${descriptor.sslTrustAllCertificates}"/>
+        </f:entry>
         
         <super:global-jenkinsLogin />
       


### PR DESCRIPTION
This feature allows Jenkins IRC bot to connect to servers with self-signed SSL certificates.
