### PR TITLE
Identify explicitly.

### DIFF
--- a/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
+++ b/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
@@ -136,7 +136,7 @@ public class IRCConnection implements IMConnection, JoinListener, InviteListener
 			
 	        final String nickServPassword = this.descriptor.getNickServPassword();
             if(Util.fixEmpty(nickServPassword) != null) {
-                this.pircConnection.identify(nickServPassword);
+                this.pircConnection.sendMessage("NickServ", "identify " + nickServPassword);
                 
                 if (!this.groupChats.isEmpty()) {
 	                // Sleep some time so chances are good we're already identified


### PR DESCRIPTION
pircConnection.identify() uses "NICKSERV <password>" to identify
a nick against the NickServ bot. However NICKSERV is not part of
RFC2812 and fails for some IRC networks. Use private message to
NickServ instead.