### PR TITLE
Add support for configuring at which rate the messages should be broadca...

### DIFF
--- a/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
+++ b/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
@@ -183,6 +183,8 @@ public class IrcPublisher extends IMPublisher {
         private String socksHost = null;
         
         private Integer socksPort = 1080;
+
+        private Integer messageRate = 500; // in milliseconds
         
         /**
          * Marks if passwords are already scrambled.
@@ -291,6 +293,13 @@ public class IrcPublisher extends IMPublisher {
                 this.commandPrefix = Util.fixEmptyAndTrim(commandPrefix);
                 
                 this.disallowPrivateChat = "on".equals(req.getParameter("irc_publisher.disallowPrivateChat"));
+
+                try {
+                    this.messageRate = Integer.valueOf(req.getParameter("irc_publisher.messageRate"));
+                } catch (NumberFormatException e) {
+                    throw new FormException("message rate field must be an Integer",
+                            "irc_publisher.messageRate");
+                }
                 
             	String[] channelsNames = req.getParameterValues("irc_publisher.channel.name");
             	String[] channelsPasswords = req.getParameterValues("irc_publisher.channel.password");
@@ -495,6 +504,8 @@ public class IrcPublisher extends IMPublisher {
         public boolean isDisallowPrivateChat() {
             return this.disallowPrivateChat;
         }
+
+        public Integer getMessageRate() { return this.messageRate; }
 
         //@Override
         public boolean isEnabled() {

--- a/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
+++ b/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
@@ -184,7 +184,7 @@ public class IrcPublisher extends IMPublisher {
         
         private Integer socksPort = 1080;
 
-        private Integer messageRate = 500; // in milliseconds
+        private Integer messageRate = getMessageRateFromSystemProperty();
         
         /**
          * Marks if passwords are already scrambled.
@@ -294,12 +294,7 @@ public class IrcPublisher extends IMPublisher {
                 
                 this.disallowPrivateChat = "on".equals(req.getParameter("irc_publisher.disallowPrivateChat"));
 
-                try {
-                    this.messageRate = Integer.valueOf(req.getParameter("irc_publisher.messageRate"));
-                } catch (NumberFormatException e) {
-                    throw new FormException("message rate field must be an Integer",
-                            "irc_publisher.messageRate");
-                }
+                this.messageRate = getMessageRateFromSystemProperty();
                 
             	String[] channelsNames = req.getParameterValues("irc_publisher.channel.name");
             	String[] channelsPasswords = req.getParameterValues("irc_publisher.channel.password");
@@ -587,6 +582,18 @@ public class IrcPublisher extends IMPublisher {
         }
 
         /**
+         * Fetches message rate, defaults to 0.5 second if none are set or invalid value.
+         * @return message rate in milliseconds
+         */
+        protected Integer getMessageRateFromSystemProperty() {
+            try {
+                return Integer.parseInt(System.getProperty("hudson.plugins.ircbot.messageRate", "500"));
+            } catch (NumberFormatException nfe) {
+                return new Integer(500);
+            }
+        }
+
+        /**
 		 * Deserialize old descriptors.
 		 */
 		@SuppressWarnings("deprecation")
@@ -607,7 +614,7 @@ public class IrcPublisher extends IMPublisher {
 			}
 
             if (this.messageRate == null) {
-                this.messageRate = 500; // in milliseconds.
+                this.messageRate = getMessageRateFromSystemProperty();
             }
 			
 			if (!this.scrambledPasswords) {

--- a/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
+++ b/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
@@ -605,6 +605,10 @@ public class IrcPublisher extends IMPublisher {
 			if (this.charset == null) {
 			    this.charset = "UTF-8";
 			}
+
+            if (this.messageRate == null) {
+                this.messageRate = 500; // in milliseconds.
+            }
 			
 			if (!this.scrambledPasswords) {
 			    this.password = Scrambler.scramble(this.password);

--- a/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
+++ b/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
@@ -72,12 +72,7 @@ public class IRCConnection implements IMConnection, JoinListener, InviteListener
 		
 	    this.pircConnection.setLogin(this.descriptor.getLogin());
         this.pircConnection.setName(this.descriptor.getNick());
-        
-        // lower delay between sending 2 messages to 500ms as we will sometimes send
-        // output which will consist of multiple lines (see comment in send method)
-        // (lowering further than this doesn't seem to work as we will otherwise be easily
-        // be throttled by IRC servers)
-        this.pircConnection.setMessageDelay(500);
+        this.pircConnection.setMessageDelay(this.descriptor.getMessageRate());
         
         this.listener = new PircListener(this.pircConnection, this.descriptor.getNick());
 	}

--- a/src/main/resources/hudson/plugins/ircbot/IrcPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/ircbot/IrcPublisher/global.jelly
@@ -76,6 +76,10 @@
         <f:entry title="Disallow Private Chat" description="Disallow bot commands from private chat.">
             <f:checkbox name="irc_publisher.disallowPrivateChat" checked="${descriptor.disallowPrivateChat}"/>
         </f:entry>
+        <f:entry title="IRC Message Rate" description="Change the delay before sending the next message. WARNING: Do not change this without understanding what it does."
+          help="/plugin/ircbot/help-globalMessageRate.html">
+            <f:textbox name="irc_publisher.messageRate" value="${descriptor.getMessageRate()}" />
+        </f:entry>
         <super:global-jenkinsLogin />
       
         <f:entry title="Notification charset" description="The character set to use for notifications">

--- a/src/main/resources/hudson/plugins/ircbot/IrcPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/ircbot/IrcPublisher/global.jelly
@@ -76,10 +76,6 @@
         <f:entry title="Disallow Private Chat" description="Disallow bot commands from private chat.">
             <f:checkbox name="irc_publisher.disallowPrivateChat" checked="${descriptor.disallowPrivateChat}"/>
         </f:entry>
-        <f:entry title="IRC Message Rate" description="Change the delay before sending the next message. WARNING: Do not change this without understanding what it does."
-          help="/plugin/ircbot/help-globalMessageRate.html">
-            <f:textbox name="irc_publisher.messageRate" value="${descriptor.getMessageRate()}" />
-        </f:entry>
         <super:global-jenkinsLogin />
       
         <f:entry title="Notification charset" description="The character set to use for notifications">
@@ -95,7 +91,9 @@
         <f:entry title="Use colors" description="If checked, the bot will send colorized messages depending on the current and previous states of a job." help="/plugin/ircbot/help-globalConfigUseColors.html">
           <f:checkbox name="${descriptor.PARAMETERNAME_USE_COLORS}" checked="${descriptor.useColors}"/>
         </f:entry>
-        
+        <f:entry title="IRC Message Rate" description="Change the delay before sending the next message can be done by changing the hudons.plugins.ircbot.messageRate system property. WARNING: Do not change this without understanding what it does."
+          help="/plugin/ircbot/help-globalMessageRate.html">
+        </f:entry>
     </f:advanced>
    </f:optionalBlock>
   </f:section>

--- a/src/main/webapp/help-globalMessageRate.html
+++ b/src/main/webapp/help-globalMessageRate.html
@@ -1,0 +1,13 @@
+<div>
+    <p>
+       Allows you to change the rate at which the bot will broadcast messages to IRC.
+
+       You should usually <font color="red">NEVER</font> change this setting, it will normally result in getting
+       your bot banned from the IRC network!
+
+       The rate is given in milliseconds.
+
+       (It's only useful for those who is running the bot towards a private network where
+        it is allowed to bypass message throttling and won't get killed/banned by the IRC daemon)
+    </p>
+</div>


### PR DESCRIPTION
...st to IRC

Defaults to 500ms which it was hardcoded to.

This allows users to lower the value for those who hosts a private IRCD where the
bot is allowed to send messages at «full speed».