### PR TITLE
Don't drop the space in front of the build status

### DIFF
--- a/src/main/java/hudson/plugins/ircbot/v2/IRCColorizer.java
+++ b/src/main/java/hudson/plugins/ircbot/v2/IRCColorizer.java
@@ -69,7 +69,7 @@ public class IRCColorizer {
                     default: return line;
                 }
                 
-                return line.substring(0, index - 1) + color + keyword + Colors.NORMAL
+                return line.substring(0, index) + color + keyword + Colors.NORMAL
                         + line.substring(index + keyword.length(), line.length());
             }
         }


### PR DESCRIPTION
Should fix https://issues.jenkins-ci.org/browse/JENKINS-22360

(I haven't tested the fix yet.)
