### PR TITLE
Adding two features, custom colorizing styles and scope of notifications

### DIFF
--- a/src/main/java/hudson/plugins/ircbot/v2/IRCColorizer.java
+++ b/src/main/java/hudson/plugins/ircbot/v2/IRCColorizer.java
@@ -4,6 +4,14 @@ import hudson.model.ResultTrend;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.HashMap;
+import java.util.Map.Entry;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.logging.Logger;
+import java.util.*;
+import java.io.*;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.pircbotx.Colors;
 
@@ -12,23 +20,150 @@ import org.pircbotx.Colors;
  * 
  * @author syl20bnr
  * @author kutzi
+ * @author tao 
+ * @author hongjae
+ * @author austin
  */
 // See http://flylib.com/books/en/4.74.1.47/1/ for some tips on IRC colors
 public class IRCColorizer {
+	
+	private static final Logger LOGGER = Logger.getLogger(IRCColorizer.class.getName());
     
     /**
      * Very simple pattern to recognize test results.
      */
     private static final Pattern TEST_CLASS_PATTERN = Pattern.compile(".*test.*", Pattern.CASE_INSENSITIVE);
-
+    
+    //userPattern store the String/Pattern->color preference for each specific user
+    //e.g.userPattern[nickname][user_prefered_string_pattern]
+    private static HashMap<String, HashMap<String, String> > userPattern; 
+    private static HashMap<String, HashMap<ResultTrend, String> > themes; 
+    private static String currentTheme;
+    private static ArrayList<ResultTrend> result;
+        
+    /**
+     * static constructor
+     * unserialize userPattern
+     * populate colorMap
+     * load a default user pattern
+     */
+    static {
+    	readFile("userPattern.ser");
+    	createThemes();
+    	currentTheme = "THEME1";
+    }
+    
+    
+    
+    /**
+     * creates default theme
+     * @return hashmap for type theme
+     */
+    public static HashMap<ResultTrend, String> createDefault() {
+    	HashMap<ResultTrend, String> theme = new HashMap<ResultTrend, String>();
+    	theme.put(ResultTrend.FIXED, Colors.BOLD + Colors.UNDERLINE + Colors.GREEN);
+    	theme.put(ResultTrend.SUCCESS, Colors.BOLD + Colors.GREEN);
+    	theme.put(ResultTrend.FAILURE, Colors.BOLD + Colors.UNDERLINE + Colors.RED);
+    	theme.put(ResultTrend.STILL_FAILING, Colors.BOLD + Colors.RED);
+    	theme.put(ResultTrend.UNSTABLE, Colors.BOLD + Colors.UNDERLINE + Colors.BROWN);
+    	theme.put(ResultTrend.STILL_UNSTABLE, Colors.BOLD + Colors.BROWN);
+    	theme.put(ResultTrend.NOW_UNSTABLE, Colors.BOLD + Colors.MAGENTA);
+    	theme.put(ResultTrend.ABORTED, Colors.BOLD + Colors.LIGHT_GRAY);
+    	
+    	return theme;
+    }
+    
+    /**
+     * creates default theme by color to change all result trend text with one color
+     * @param color color string
+     * @return hashmap for type theme
+     */
+    public static HashMap<ResultTrend, String> oneColorTheme(String color) {
+    	HashMap<ResultTrend, String> theme = new HashMap<ResultTrend, String>();
+    	String colorString = IRCColors.lookup(color);
+    	theme.put(ResultTrend.FIXED, Colors.BOLD + Colors.UNDERLINE + colorString);
+    	theme.put(ResultTrend.SUCCESS, Colors.BOLD + colorString);
+    	theme.put(ResultTrend.FAILURE, Colors.BOLD + Colors.UNDERLINE + colorString);
+    	theme.put(ResultTrend.STILL_FAILING, Colors.BOLD + colorString);
+    	theme.put(ResultTrend.UNSTABLE, Colors.BOLD + Colors.UNDERLINE + colorString);
+    	theme.put(ResultTrend.STILL_UNSTABLE, Colors.BOLD + colorString);
+    	theme.put(ResultTrend.NOW_UNSTABLE, Colors.BOLD + colorString);
+    	theme.put(ResultTrend.ABORTED, Colors.BOLD + colorString);
+    	
+    	return theme;
+    }
+    
+    /**
+     * creates default theme 2
+     * @return hashmap for type theme
+     */
+    public static HashMap<ResultTrend, String> theme2() {
+    	HashMap<ResultTrend, String> theme = new HashMap<ResultTrend, String>();
+    	theme.put(ResultTrend.FIXED, Colors.BOLD + Colors.UNDERLINE + Colors.BLUE);
+    	theme.put(ResultTrend.SUCCESS, Colors.BOLD + Colors.BLUE);
+    	theme.put(ResultTrend.FAILURE, Colors.BOLD + Colors.UNDERLINE + Colors.RED);
+    	theme.put(ResultTrend.STILL_FAILING, Colors.BOLD + Colors.RED);
+    	theme.put(ResultTrend.UNSTABLE, Colors.BOLD + Colors.UNDERLINE + Colors.MAGENTA);
+    	theme.put(ResultTrend.STILL_UNSTABLE, Colors.BOLD + Colors.MAGENTA);
+    	theme.put(ResultTrend.NOW_UNSTABLE, Colors.BOLD + Colors.RED);
+    	theme.put(ResultTrend.ABORTED, Colors.BOLD + Colors.BLACK);
+    	
+    	return theme;
+    }
+    
+    /**
+     * clean userPattern by nickname
+     * @param nickname user's nickname
+     */
+    public static void cleanUserPattern(String nickname)
+	{
+    	userPattern.remove(nickname);
+    	currentTheme = "THEME1";
+	}
+    
+    /**
+     * changes theme to specific theme
+     * @param theme
+     */
+    public static String changeTheme(String theme) {
+    	//check to make sure the theme exists
+        if (themes.get(theme) == null) {
+            return currentTheme;
+        }
+        currentTheme = theme;
+        return currentTheme;
+    }
+    
+    /**
+     * get userPattern size
+     * @return size of userPattern
+     */
+    public static int getSize()
+	{
+    	return userPattern.size();
+	}
+    
+    /**
+     * get user's Pattern->color size by nickname
+     * @param nickname user's nickname
+     * @return size of user pattern related to nickname
+     */
+    public static int getSizeByNickName(String nickname)
+	{
+    	return userPattern.get(nickname).size();
+	}
+    
+    
     /**
      * Colorize the message line if certain keywords are found in it. 
+     * @param message message that needs to be changed
      */
     public static String colorize(String message){
         
         if(message.contains("Starting ")) {
             return message;
         } else {
+        	
             String line = colorForBuildResult(message);
             if (line == message) { // line didn't contain a build result
                 Matcher m = TEST_CLASS_PATTERN.matcher(message);
@@ -40,25 +175,108 @@ public class IRCColorizer {
         }
     }
     
+    /**
+     * Colorize the message line if certain keywords are found in it. 
+     * @param nickname user's nickname
+     * @param message jenkin's message
+     */
+    public static String colorize(String nickname, String message) {
+    	if(userPattern.containsKey(nickname)){
+            return user_colorize(nickname, message);
+    	} else {
+    		return colorize(message);
+    	}
+    }
+    
+    /**
+     * set the user defined color for specific string,
+     * will be called by onMessage() method in PircListener.java
+     * @param nickname user's nickname
+     * @param pattern patterns that user wants to change, it also includes regex
+     * @param color e.g RED, BLUE, GREEN
+     */
+    public static void setter(String nickname, String pattern, String color) 
+    {
+        // get hashmap for userid or create a new one
+        HashMap<String, String> user_hash;
+        if(userPattern.containsKey(nickname)){
+            user_hash = userPattern.get(nickname);
+        } else {
+            user_hash = new HashMap<String, String>();
+        }
+        
+        for(String name: user_hash.keySet()) {
+        	System.out.println(name + " : " + user_hash.get(name));
+        }
+
+        // with user_hash add Pattern and String-color
+        user_hash.put(pattern, color);
+        
+        // put user_hash back into userPattern
+        userPattern.put(nickname, user_hash);
+        
+        // Serialize userPattern to disk
+        writeFile("userPattern.ser");        
+    }
+    
+    // creates default Themes
+    private static void createThemes() {
+    	themes = new HashMap<String, HashMap<ResultTrend,String>>();
+    	themes.put("THEME1", createDefault());
+    	themes.put("THEME2", oneColorTheme("OLIVE"));
+    	themes.put("THEME3", theme2());
+    }
+    
+    //set the message with user preference if the preference can be retrieved in userPattern
+    private static String user_colorize(String nickname, String message)
+    {
+    	if(!userPattern.containsKey(nickname)) {
+        	return message;
+        }
+        // get hashmap for userid or create a new one
+        HashMap<String, String> user_hash;
+        
+        user_hash = userPattern.get(nickname);
+        
+        // replace var
+        String new_text;
+
+        for(Map.Entry<String, String> user_patterns_iter: user_hash.entrySet()) {
+            // we are getting each pattern 1 at a time
+            String upString = user_patterns_iter.getKey();
+            Pattern up = Pattern.compile(upString);
+            String ucolor = IRCColors.lookup(user_patterns_iter.getValue().trim());
+
+            // collect all the matches in the group
+            HashSet<String> matches = new HashSet<String>();
+            Matcher m = up.matcher(message);
+            while(m.find()) {
+                
+            	matches.add(m.group());
+            }
+
+            // for each work in the set of matches
+            // replace will color
+            Iterator<String> matches_iter = matches.iterator();
+            while(matches_iter.hasNext()) {
+                String text = matches_iter.next();
+                new_text = ucolor + text + Colors.NORMAL;
+                message = message.replaceAll(text, new_text);
+            }
+        }
+        return message;
+    }
+
+    // Receives a string and applies colors based on theme colors to specific string
     private static String colorForBuildResult(String line) {
         for (ResultTrend result : ResultTrend.values()) {
-            
             String keyword = result.getID();
             
             int index = line.indexOf(keyword);
             if (index != -1) {
                 final String color;
-                switch (result) {
-                    case FIXED: color = Colors.BOLD + Colors.UNDERLINE + Colors.GREEN; break;
-                    case SUCCESS: color = Colors.BOLD + Colors.GREEN; break;
-                    case FAILURE: color = Colors.BOLD + Colors.UNDERLINE + Colors.RED; break;
-                    case STILL_FAILING: color = Colors.BOLD + Colors.RED; break;
-                    case UNSTABLE: color = Colors.BOLD + Colors.UNDERLINE + Colors.BROWN; break;
-                    case STILL_UNSTABLE: color = Colors.BOLD + Colors.BROWN; break;
-                    case NOW_UNSTABLE: color = Colors.BOLD + Colors.MAGENTA; break;
-                    case ABORTED: color = Colors.BOLD + Colors.LIGHT_GRAY; break;
-                    default: return line;
-                }
+                HashMap<ResultTrend, String> temp = themes.get(currentTheme);
+                color = temp.get(result);
                 
                 return line.substring(0, index) + color + keyword + Colors.NORMAL
                         + line.substring(index + keyword.length(), line.length());
@@ -66,5 +284,37 @@ public class IRCColorizer {
         }
         return line;
     }
-
+    
+    // write data into a file
+    private static void writeFile(String fileName) {
+        ObjectOutputStream oos = null;
+    	try {
+    		FileOutputStream fout = new FileOutputStream("./"+fileName);
+    		oos = new ObjectOutputStream(fout);
+    		oos.writeObject(userPattern);
+    		oos.close();
+    	} catch(IOException ex) {
+    		ex.printStackTrace();
+    	} 
+    }
+    
+    // read data from a file
+    private static void readFile(String fileName) {
+    	if(userPattern == null) {
+    		userPattern = new HashMap<String, HashMap<String, String> >();
+    	}
+    	
+    	try {
+    		FileInputStream fis = new FileInputStream("./"+fileName);
+    		InputStream buffer = new BufferedInputStream(fis);
+    		ObjectInput input = new ObjectInputStream(buffer);
+    		
+    		userPattern = (HashMap<String, HashMap<String, String>>)input.readObject();
+    		buffer.close();
+    	} catch (ClassNotFoundException ex) {
+    		ex.printStackTrace();
+    	} catch(IOException ex) {
+    		ex.printStackTrace();
+    	}
+    }
 }

--- a/src/main/java/hudson/plugins/ircbot/v2/IRCColorizer.java
+++ b/src/main/java/hudson/plugins/ircbot/v2/IRCColorizer.java
@@ -223,7 +223,7 @@ public class IRCColorizer {
     private static void createThemes() {
     	themes = new HashMap<String, HashMap<ResultTrend,String>>();
     	themes.put("THEME1", createDefault());
-    	themes.put("THEME2", oneColorTheme("OLIVE"));
+    	themes.put("THEME2", oneColorTheme("CYAN"));
     	themes.put("THEME3", theme2());
     }
     

--- a/src/main/java/hudson/plugins/ircbot/v2/IRCColors.java
+++ b/src/main/java/hudson/plugins/ircbot/v2/IRCColors.java
@@ -1,0 +1,296 @@
+/**
+ * Copyright (C) 2010-2014 Leon Blakey <lord.quackstar at gmail.com>
+ *
+ * This file is part of PircBotX.
+ *
+ * PircBotX is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * PircBotX is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * PircBotX. If not, see <http://www.gnu.org/licenses/>.
+ */
+package hudson.plugins.ircbot.v2;
+
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * The Colors class provides several static fields and methods that you may find
+ * useful when writing an IRC Bot.
+ * <p>
+ * This class contains constants that are useful for formatting lines sent to
+ * IRC servers. These constants allow you to apply various formatting to the
+ * lines, such as colours, boldness, underlining and reverse text.
+ * <p>
+ * The class contains static methods to remove colours and formatting from lines
+ * of IRC text.
+ * <p>
+ * Here are some examples of how to use the constants
+ * <pre>
+ * message(Colors.BOLD + "A bold hello!");
+ * <b>A bold hello!</b>
+ * message(Colors.RED + "Red" + Colors.NORMAL + " text");
+ * <font color="red">Red</font> text
+ * message(Colors.BOLD + Colors.RED + "Bold and red");
+ * <b><font color="red">Bold and red</font></b></pre>
+ * <p/>
+ * Please note that some IRC channels may be configured to reject any messages
+ * that use colours. Also note that older IRC clients may be unable to correctly
+ * display lines that contain colours and other control characters.
+ * <p>
+ * Note that this class name has been spelt in the American style in order to
+ * remain consistent with the rest of the Java API.
+ *
+ *
+ * @since PircBot 0.9.12
+ * @author Origionally by:
+ * <a href="http://www.jibble.org/">Paul James Mutton</a> for <a
+ * href="http://www.jibble.org/pircbot.php">PircBot</a>
+ * <p>
+ * Forked and Maintained by Leon Blakey in <a
+ * href="http://github.com/thelq/pircbotx">PircBotX</a>
+ */
+public final class IRCColors {
+	/**
+	 * Removes all previously applied color and formatting attributes.
+	 */
+	public static final String NORMAL = "\u000f";
+	/**
+	 * Bold text.
+	 */
+	public static final String BOLD = "\u0002";
+	/**
+	 * Underlined text.
+	 */
+	public static final String UNDERLINE = "\u001f";
+	/**
+	 * Reversed text (may be rendered as italic text in some clients).
+	 */
+	public static final String REVERSE = "\u0016";
+	/**
+	 * White coloured text.
+	 */
+	public static final String WHITE = "\u000300";
+	/**
+	 * Black coloured text.
+	 */
+	public static final String BLACK = "\u000301";
+	/**
+	 * Dark blue coloured text.
+	 */
+	public static final String DARK_BLUE = "\u000302";
+	/**
+	 * Dark green coloured text.
+	 */
+	public static final String DARK_GREEN = "\u000303";
+	/**
+	 * Red coloured text.
+	 */
+	public static final String RED = "\u000304";
+	/**
+	 * Brown coloured text.
+	 */
+	public static final String BROWN = "\u000305";
+	/**
+	 * Purple coloured text.
+	 */
+	public static final String PURPLE = "\u000306";
+	/**
+	 * Olive coloured text.
+	 */
+	public static final String OLIVE = "\u000307";
+	/**
+	 * Yellow coloured text.
+	 */
+	public static final String YELLOW = "\u000308";
+	/**
+	 * Green coloured text.
+	 */
+	public static final String GREEN = "\u000309";
+	/**
+	 * Teal coloured text.
+	 */
+	public static final String TEAL = "\u000310";
+	/**
+	 * Cyan coloured text.
+	 */
+	public static final String CYAN = "\u000311";
+	/**
+	 * Blue coloured text.
+	 */
+	public static final String BLUE = "\u000312";
+	/**
+	 * Magenta coloured text.
+	 */
+	public static final String MAGENTA = "\u000313";
+	/**
+	 * Dark gray coloured text.
+	 */
+	public static final String DARK_GRAY = "\u000314";
+	/**
+	 * Light gray coloured text.
+	 */
+	public static final String LIGHT_GRAY = "\u000315";
+	/**
+	 * Italicized text.
+	 */
+	public static final String ITALICS = "\u001d";
+	/**
+	 * Pre-built lookup table by String for all available colors
+	 */
+	public static final ImmutableMap<String, String> COLORS_TABLE = ImmutableMap.<String, String>builder()
+			.put("WHITE", WHITE)
+			.put("BLACK", BLACK)
+			.put("DARK_BLUE", DARK_BLUE)
+			.put("DARK_GREEN", DARK_GREEN)
+			.put("RED", RED)
+			.put("BROWN", BROWN)
+			.put("PURPLE", PURPLE)
+			.put("OLIVE", OLIVE)
+			.put("YELLOW", YELLOW)
+			.put("GREEN", GREEN)
+			.put("TEAL", TEAL)
+			.put("CYAN", CYAN)
+			.put("BLUE", BLUE)
+			.put("MAGENTA", MAGENTA)
+			.put("DARK_GRAY", DARK_GRAY)
+			.put("LIGHT_GRAY", LIGHT_GRAY)
+			.build();
+	/**
+	 * Pre-built lookup table by String for all available formatting options
+	 */
+	public static final ImmutableMap<String, String> FORMATTING_TABLE = ImmutableMap.<String, String>builder()
+			.put("NORMAL", NORMAL)
+			.put("BOLD", BOLD)
+			.put("UNDERLINE", UNDERLINE)
+			.put("REVERSE", REVERSE)
+			.put("ITALICS", ITALICS)
+			.build();
+	/**
+	 * Pre-built lookup table by String for all the fields in this class.
+	 */
+	public static final ImmutableMap<String, String> LOOKUP_TABLE = ImmutableMap.<String, String>builder()
+			.putAll(COLORS_TABLE)
+			.putAll(FORMATTING_TABLE)
+			.build();
+	
+
+	/**
+	 * This class should not be constructed.
+	 */
+	private IRCColors() {
+	}
+
+	/**
+	 * Lookup color as a String
+	 *
+	 * @param colorName Name of field in this class, will be converted to
+	 * uppercase
+	 * @return Color value or null
+	 */
+	public static String lookup(String colorName) {
+		return LOOKUP_TABLE.get(colorName.toUpperCase());
+	}
+
+	/**
+	 * Removes all colours from a line of IRC text.
+	 *
+	 * @since PircBot 1.2.0
+	 *
+	 * @param line the input text.
+	 *
+	 * @return the same text, but with all colours removed.
+	 */
+	public static String removeColors(String line) {
+		int length = line.length();
+		StringBuilder buffer = new StringBuilder();
+		int i = 0;
+		while (i < length) {
+			char ch = line.charAt(i);
+			if (ch == '\u0003') {
+				i++;
+				// Skip "x" or "xy" (foreground color).
+				if (i < length) {
+					ch = line.charAt(i);
+					if (Character.isDigit(ch)) {
+						i++;
+						if (i < length) {
+							ch = line.charAt(i);
+							if (Character.isDigit(ch))
+								i++;
+						}
+						// Now skip ",x" or ",xy" (background color).
+						if (i < length) {
+							ch = line.charAt(i);
+							if (ch == ',') {
+								i++;
+								if (i < length) {
+									ch = line.charAt(i);
+									if (Character.isDigit(ch)) {
+										i++;
+										if (i < length) {
+											ch = line.charAt(i);
+											if (Character.isDigit(ch))
+												i++;
+										}
+									} else
+										// Keep the comma.
+										i--;
+								} else
+									// Keep the comma.
+									i--;
+							}
+						}
+					}
+				}
+			} else if (ch == '\u000f')
+				i++;
+			else {
+				buffer.append(ch);
+				i++;
+			}
+		}
+		return buffer.toString();
+	}
+
+	/**
+	 * Remove formatting from a line of IRC text.
+	 *
+	 * @since PircBot 1.2.0
+	 *
+	 * @param line the input text.
+	 *
+	 * @return the same text, but without any bold, underlining, reverse, etc.
+	 */
+	public static String removeFormatting(String line) {
+		int length = line.length();
+		StringBuilder buffer = new StringBuilder();
+		for (int i = 0; i < length; i++) {
+			char ch = line.charAt(i);
+			//Filter characters
+			if (ch != '\u000f' && ch != '\u0002' && ch != '\u001f' && ch != '\u0016')
+				buffer.append(ch);
+		}
+		return buffer.toString();
+	}
+
+	/**
+	 * Removes all formatting and colours from a line of IRC text.
+	 *
+	 * @since PircBot 1.2.0
+	 *
+	 * @param line the input text.
+	 *
+	 * @return the same text, but without formatting and colour characters.
+	 *
+	 */
+	public static String removeFormattingAndColors(String line) {
+		return removeFormatting(removeColors(line));
+	}
+}

--- a/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
+++ b/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.Date;
 
 import javax.net.SocketFactory;
 import javax.net.ssl.SSLSocketFactory;
@@ -142,20 +143,6 @@ public class IRCConnection implements IMConnection, JoinListener, InviteListener
 	public void close() {
 	    this.listener.explicitDisconnect = true;
 	    
-//		if (this.pircConnection != null) {
-//			if (this.pircConnection.isConnected()) {
-//	            this.listener.removeJoinListener(this);
-//	            this.listener.removePartListener(this);
-//	            this.listener.removeInviteListener(this);
-//	            
-//				this.pircConnection.disconnect();
-//			}
-//			
-//			// Perform a proper shutdown, also freeing all the resources (input-/output-thread)
-//			// Note that with PircBotx 2.x the threads are gone and we can maybe simplify this
-//			this.pircConnection.shutdown(true);
-//		}
-	    
 	    if (botThread != null) {
 	    	this.botThread.interrupt();
 	    }
@@ -220,26 +207,6 @@ public class IRCConnection implements IMConnection, JoinListener, InviteListener
 			
 			pircConnection.getConfiguration().getListenerManager().removeListener(connectListener);
 
-
-			
-//	        final String nickServPassword = this.descriptor.getNickServPassword();
-//            if(Util.fixEmpty(nickServPassword) != null) {
-//                this.pircConnection.identify(nickServPassword);
-//                
-//                if (!this.groupChats.isEmpty()) {
-//	                // Sleep some time so chances are good we're already identified
-//	                // when we try to join the channels.
-//	                // Unfortunately there seems to be no standard way in IRC to recognize
-//	                // if one has been identified already.
-//	                LOGGER.fine("Sleeping some time to wait for being authenticated");
-//	                try {
-//						Thread.sleep(TimeUnit.SECONDS.toMillis(5));
-//					} catch (InterruptedException e) {
-//						// ignore
-//					}
-//                }
-//            }
-            
             joinGroupChats();
 			
 			return pircConnection.isConnected();
@@ -393,6 +360,14 @@ public class IRCConnection implements IMConnection, JoinListener, InviteListener
 	    send(target.toString(), text);
 	}
 	
+    /**
+     * 
+     * send a message to PircBotx in the target channel
+     * 
+     * @param target target channel
+     * @param text sending message
+     * @throws IMException Represents any kind of protocol-level error that may occur
+     */
 	public void send(String target, String text) throws IMException {
 	    Channel channel = this.pircConnection.getUserChannelDao().getChannel(target);
 	    
@@ -407,10 +382,15 @@ public class IRCConnection implements IMConnection, JoinListener, InviteListener
 
         // IRC doesn't support multiline messages (see http://stackoverflow.com/questions/7039478/linebreak-irc-protocol)
 	    // therefore we split the message on line breaks and send each line as its own message:
-        String[] lines = text.split("\\r?\\n|\\r");
+        String[] lines = text.split("\\r?\\n|\\r|\\n");
         for (String line : lines) {
+            // add wait here to prevent flood
+            long start = new Date().getTime();
+            while(new Date().getTime() - start < 1000L){}
+
             if (useColors){
-                line = IRCColorizer.colorize(line);
+                // target should be the name of the channel or the name of the user to which a private message is directed.
+                line = IRCColorizer.colorize(target, line);
             }
             if (this.descriptor.isUseNotice()) {
                 this.pircConnection.sendIRC().notice(target, line);

--- a/src/main/java/hudson/plugins/ircbot/v2/PircListener.java
+++ b/src/main/java/hudson/plugins/ircbot/v2/PircListener.java
@@ -1,16 +1,20 @@
-/**
- * 
- */
 package hudson.plugins.ircbot.v2;
 
 import hudson.plugins.im.IMConnectionListener;
 import hudson.plugins.im.IMMessage;
 import hudson.plugins.im.IMMessageListener;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Logger;
+import java.util.Arrays;
+import java.util.HashMap;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.pircbotx.PircBotX;
 import org.pircbotx.hooks.ListenerAdapter;
 import org.pircbotx.hooks.events.DisconnectEvent;
@@ -24,6 +28,7 @@ import org.pircbotx.hooks.events.NoticeEvent;
 import org.pircbotx.hooks.events.PartEvent;
 import org.pircbotx.hooks.events.PrivateMessageEvent;
 import org.pircbotx.hooks.events.ServerResponseEvent;
+import org.pircbotx.hooks.types.GenericMessageEvent;
 
 import edu.umd.cs.findbugs.annotations.SuppressWarnings;
 
@@ -35,189 +40,299 @@ import edu.umd.cs.findbugs.annotations.SuppressWarnings;
  */
 public class PircListener extends ListenerAdapter<PircBotX> {
 
-	private static final Logger LOGGER = Logger.getLogger(PircListener.class.getName());
-	
+	private static final Logger LOGGER = Logger.getLogger(PircListener.class
+			.getName());
+
 	@SuppressWarnings(value = "DM_STRING_CTOR", justification = "we want a new instance here to enable reference comparison")
-	public static final String CHAT_ESTABLISHER = new String("<<<ChatEstablisher>>>");
-	
+	public static final String CHAT_ESTABLISHER = new String(
+			"<<<ChatEstablisher>>>");
+
 	private final List<IMConnectionListener> listeners = new CopyOnWriteArrayList<IMConnectionListener>();
-	
+
 	private final List<MessageListener> msgListeners = new CopyOnWriteArrayList<MessageListener>();
-	
+
 	private final List<JoinListener> joinListeners = new CopyOnWriteArrayList<JoinListener>();
 
-    private final List<InviteListener> inviteListeners = new CopyOnWriteArrayList<InviteListener>();
+	private final List<InviteListener> inviteListeners = new CopyOnWriteArrayList<InviteListener>();
 
-    private final List<PartListener> partListeners = new CopyOnWriteArrayList<PartListener>();
-    
-	
+	private final List<PartListener> partListeners = new CopyOnWriteArrayList<PartListener>();
+
 	volatile boolean explicitDisconnect = false;
-	
-	
+
 	@java.lang.SuppressWarnings("unused")
 	private final PircBotX pircBot;
-    private final String nick;
+	private final String nick;
+	private static final String onlyIndicator = "only";
+	private final String fmtIndicator = " set color ";
 
+	/**
+	 * PircListener constructor
+	 * @param pircBot pircBot
+	 * @param nick nickname of a user
+	 */
 	public PircListener(PircBotX pircBot, String nick) {
-	    this.pircBot = pircBot;
-	    this.nick = nick;
-    }
-
-//	/**
-//	 * {@inheritDoc}
-//	 */
-//    @Override
-//    protected void handleLine(String line) {
-//        LOGGER.fine(line);
-//        super.handleLine(line);
-//    }
-
-    /**
-     * {@inheritDoc} 
-     */
-    @Override
-    public void onMessage(MessageEvent<PircBotX> event) {
-    	for (MessageListener l : this.msgListeners) {
-    		if(l.target.equals(event.getChannel().getName())) {
-    			l.listener.onMessage(new IMMessage(event.getUser().getNick(),
-    			        event.getChannel().getName(), event.getMessage()));
-    		}
-    	}
-    }
-
-    /**
-     * {@inheritDoc} 
-     */
-    @Override
-    public void onPrivateMessage(PrivateMessageEvent<PircBotX> event) {
-        String sender = event.getUser().getNick();
-        String message = event.getMessage();
-    	for (MessageListener l : this.msgListeners) {
-    		if (this.nick.equals(l.target)) {
-    		    if (l.sender == CHAT_ESTABLISHER || sender.equals(l.sender)) {
-    		        l.listener.onMessage(new IMMessage(sender, this.nick, message));
-    		    }
-    		}
-    	}
-    }
-    
-    /**
-     * Someone send me a notice. Possibly NickServ after identifying.
-     */
-    @Override
-	public void onNotice(NoticeEvent<PircBotX> event) {
-        String sourceNick = event.getUser().getNick();
-        String notice = event.getMessage();
-		LOGGER.info("Notice from " + sourceNick + ": '" + normalize(notice) + "'");
+		this.pircBot = pircBot;
+		this.nick = nick;
 	}
 
 	/**
-     * {@inheritDoc}
-     */
-    @Override
-    public void onJoin(JoinEvent<PircBotX> event) {
-        String sender = event.getUser().getNick();
-    	for (JoinListener l : this.joinListeners) {
-    		if (this.nick.equals(sender)) {
-    			l.channelJoined(event.getChannel().getName());
-    		}
-    	}
-    }
+	 * Controls a message sent from PircBotx
+	 * when event has only or format indicator, 
+	 * message is not send it to other event listener, but modifies in the IRC plugin.
+	 * 
+	 * @param event user's is received via PircBotx
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void onMessage(MessageEvent<PircBotX> event) {
+		if (event.getMessage().contains(onlyIndicator)) {
+			onMultiMessage(event);
+		} else if (event.getMessage().contains(fmtIndicator)) {
+			onFormatMessage(event);
+		} else {
+			for (MessageListener l : this.msgListeners) {
+				if (l.target.equals(event.getChannel().getName())) {
+					l.listener.onMessage(new IMMessage(event.getUser()
+							.getNick(), event.getChannel().getName(), event
+							.getMessage()));
+				}
+			}
+		}
+	}
 
-    @Override
-    public void onPart(PartEvent<PircBotX> event) {
-        String sender = event.getUser().getNick();
-        for (PartListener l : this.partListeners) {
-            if (this.nick.equals(sender)) {
-                l.channelParted(event.getChannel().getName());
-            }
-        }
-    }
+	/**
+	 * Gets usernames from message passed by PircBotx (with "only" flag).
+	 * 
+	 * @param msg
+	 * @param noUser
+	 * @return list of usernames that were passed with the "only" flag
+	 */
+	public static LinkedHashSet<String> getRecipients(String msg, String noUser) {
+		// get the index of the character after the space after the indicator
+		// !jenkins ... only asdf,qwert
+		// ^
+		int index = msg.indexOf(onlyIndicator) + onlyIndicator.length() + 1;
+		if (index >= msg.length()) {
+			LOGGER.warning("No recipients passed. Usage: !jenkins ... only user1,user2,...");
+			return new LinkedHashSet<String>();
+		}
 
-    @Override
-    public void onKick(KickEvent<PircBotX> event) {
-        String recipientNick = event.getRecipient().getNick();
-        for(PartListener l : this.partListeners) {
-            if (this.nick.equals(recipientNick)) {
-                l.channelParted(event.getChannel().getName());
-            }
-        }
-    }
-    
-    @Override
-    public void onServerResponse(ServerResponseEvent<PircBotX> event) {
-        int code = event.getCode();
-        
+		// grabbing recipients from message and removing whitespace (replaceAll)
+		String args = msg.substring(index, msg.length()).replaceAll("\\s+", "");
+		LinkedHashSet<String> ret = new LinkedHashSet<String>(Arrays.asList(args.split(",")));
+		ret.remove(noUser);
+
+		return ret;
+	}
+
+	// Controls color format of a message.
+	// Message looks like this.
+	// !jenkins set color THEME1
+	// !jenkins set color regex COLORS(e.g, RED, GREED)
+	private void onFormatMessage(GenericMessageEvent<PircBotX> event) {
+		String msg = event.getMessage();
+		String nick = event.getUser().getNick();
+
+		// parse out jenkins prefix, nickname, pattern and color from message
+		// !jenkins pattern color
+		String[] tokens = msg.split(" ");
+		LOGGER.info("----- start ------");
+
+		String color;
+		if (tokens.length == 5) {
+			// token 0: jenkins prefix
+			// token 1: regex pattern
+			// token 2: color
+
+			// check for color code in Colors to see if it can be applied
+			color = IRCColors.lookup(tokens[4]);
+			if (color != null) {
+				IRCColorizer.setter(nick, tokens[3], tokens[4]);
+				LOGGER.info("FORMAT " + nick + " " + tokens[3] + " "
+						+ tokens[4]);
+			} else {
+				LOGGER.warning("color not found!\n");
+			}
+		} else if (tokens.length == 4) {
+			if (tokens[3].equals("CLEAR")) {
+				IRCColorizer.cleanUserPattern(nick);
+			} else if (tokens[3].startsWith("THEME")) {
+				IRCColorizer.changeTheme(tokens[3]);
+			}
+		} else {
+			LOGGER.warning("could not set color! wrong number of tokens\n");
+		}
+
+	}
+
+	/**
+	 * Gets part of message from irc that does not include any "only" params.
+	 * 
+	 * @param msg
+	 * @return message sent from irc up to the only indicator ("only")
+	 */
+	public static String getMultiMessage(String msg) {
+		return msg.substring(0, msg.indexOf(onlyIndicator));
+	}
+
+	private void onMultiMessage(GenericMessageEvent<PircBotX> event) {
+		String msg = event.getMessage();
+		ArrayList<String> recipients = new ArrayList<String>();
+		recipients.add(event.getUser().getNick());
+		// add all recipients to list
+		recipients.addAll(getRecipients(msg, recipients.get(0)));
+		// modify message to not contain only
+		msg = getMultiMessage(msg);
+		if (msg.contains(onlyIndicator)) {
+			LOGGER.warning("Multiple only indicators in message! I'm ignoring your command!");
+			return;
+		}
+		for (String r : recipients) {
+			// create a new private message event to dispatch to user
+			PrivateMessageEvent<PircBotX> newEvent = new PrivateMessageEvent<PircBotX>(
+					event.getBot(), event.getBot().getUserChannelDao()
+							.getUser(r), msg);
+			onPrivateMessage(newEvent);
+		}
+	}
+
+	/**
+	 * Controls a private message sent from PircBotx,
+	 * but when the only indicator is sent up then the IRC plugin controls its message.
+	 * 
+	 * @param event user's is received via PircBotx
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void onPrivateMessage(PrivateMessageEvent<PircBotX> event) {
+		String sender = event.getUser().getNick();
+		String message = event.getMessage();
+		if (message.contains(onlyIndicator)) {
+			onMultiMessage(event);
+		} else {
+			for (MessageListener l : this.msgListeners) {
+				if (this.nick.equals(l.target)) {
+					if (l.sender == CHAT_ESTABLISHER || sender.equals(l.sender)) {
+						l.listener.onMessage(new IMMessage(sender, this.nick,
+								message));
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Someone send me a notice. Possibly NickServ after identifying.
+	 * 
+	 * @param event user's is received via PircBotx
+	 */
+	@Override
+	public void onNotice(NoticeEvent<PircBotX> event) {
+		String sourceNick = event.getUser().getNick();
+		String notice = event.getMessage();
+		LOGGER.info("Notice from " + sourceNick + ": '" + normalize(notice)
+				+ "'");
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void onJoin(JoinEvent<PircBotX> event) {
+		String sender = event.getUser().getNick();
+		for (JoinListener l : this.joinListeners) {
+			if (this.nick.equals(sender)) {
+				l.channelJoined(event.getChannel().getName());
+			}
+		}
+	}
+
+	@Override
+	public void onPart(PartEvent<PircBotX> event) {
+		String sender = event.getUser().getNick();
+		for (PartListener l : this.partListeners) {
+			if (this.nick.equals(sender)) {
+				l.channelParted(event.getChannel().getName());
+			}
+		}
+	}
+
+	@Override
+	public void onKick(KickEvent<PircBotX> event) {
+		String recipientNick = event.getRecipient().getNick();
+		for (PartListener l : this.partListeners) {
+			if (this.nick.equals(recipientNick)) {
+				l.channelParted(event.getChannel().getName());
+			}
+		}
+	}
+
+	@Override
+	public void onServerResponse(ServerResponseEvent<PircBotX> event) {
+		int code = event.getCode();
+
 		if (code == 433) {
 			return; // should be handled by onNickAlreadyInUse
 		}
-        
-    	if (code >= 400 && code <= 599) {
-    		LOGGER.warning("IRC server responded error " + code + " Message:\n" +
-    				event.getParsedResponse());
-    	}
-    }
-    
-    public void onNickChange(NickChangeEvent<PircBotX> event){
-        LOGGER.info("Nick '" + event.getOldNick() + "' was changed. Now it is used nick '" + event.getNewNick() + "'.");
-    }
-    
-    public void onNickAlreadyInUse(NickAlreadyInUseEvent<PircBotX> event){
-        LOGGER.warning("Nick '" + nick + "' is already in use ");
-//        String nickservPass = IrcPublisher.DESCRIPTOR.getNickServPassword();
-//        if(nickservPass!=null){
-//            LOGGER.info("Nick '" + nick + "' is already in use, trying to regain it.");
-//            String userservPass = IrcPublisher.DESCRIPTOR.getUserservPassword();
-//            String userName = IrcPublisher.DESCRIPTOR.getUserName();
-//            String nick = IrcPublisher.DESCRIPTOR.getNick();
-//            if(userservPass!=null && userName!=null)
-//                pircBot.sendIRC().message("USERSERV", "login " + userName + " " + userservPass);
-//            pircBot.sendIRC().message("NICKSERV", "regain " + nick + " " + nickservPass);
-//            pircBot.sendIRC().changeNick(nick);
-//        }
-    }
-    
-    @Override
-	public void onDisconnect(DisconnectEvent<PircBotX> event) {
-        
-    	if (!explicitDisconnect) {
-	    	for (IMConnectionListener l : this.listeners) {
-	    		l.connectionBroken(null);
-	    	}
-    	}
-    	explicitDisconnect = false;
+
+		if (code >= 400 && code <= 599) {
+			LOGGER.warning("IRC server responded error " + code + " Message:\n"
+					+ event.getParsedResponse());
+		}
 	}
 
-    @Override
-    public void onInvite(InviteEvent<PircBotX> event) {
-        for (InviteListener listener : inviteListeners) {
-            listener.inviteReceived(event.getChannel(), event.getUser());
-        }
-    }
+	public void onNickChange(NickChangeEvent<PircBotX> event) {
+		LOGGER.info("Nick '" + event.getOldNick()
+				+ "' was changed. Now it is used nick '" + event.getNewNick()
+				+ "'.");
+	}
 
+	public void onNickAlreadyInUse(NickAlreadyInUseEvent<PircBotX> event) {
+		LOGGER.warning("Nick '" + nick + "' is already in use ");
+	}
 
-    // Note that the add/removeXyzListener methods needn't be synchronized because of the CopyOnWriteLists
-    
+	@Override
+	public void onDisconnect(DisconnectEvent<PircBotX> event) {
+
+		if (!explicitDisconnect) {
+			for (IMConnectionListener l : this.listeners) {
+				l.connectionBroken(null);
+			}
+		}
+		explicitDisconnect = false;
+	}
+
+	@Override
+	public void onInvite(InviteEvent<PircBotX> event) {
+		for (InviteListener listener : inviteListeners) {
+			listener.inviteReceived(event.getChannel(), event.getUser());
+		}
+	}
+
+	// Note that the add/removeXyzListener methods needn't be synchronized
+	// because of the CopyOnWriteLists
+
 	public void addConnectionListener(IMConnectionListener listener) {
-    	this.listeners.add(listener);
-    }
-    
-    public void removeConnectionListener(IMConnectionListener listener) {
-    	this.listeners.remove(listener);
-    }
-    
-    public void addMessageListener(String target, IMMessageListener listener) {
-        this.msgListeners.add(new MessageListener(target, listener));
-    }
+		this.listeners.add(listener);
+	}
 
-	public void addMessageListener(String target, String sender, IMMessageListener listener) {
+	public void removeConnectionListener(IMConnectionListener listener) {
+		this.listeners.remove(listener);
+	}
+
+	public void addMessageListener(String target, IMMessageListener listener) {
+		this.msgListeners.add(new MessageListener(target, listener));
+	}
+
+	public void addMessageListener(String target, String sender,
+			IMMessageListener listener) {
 		this.msgListeners.add(new MessageListener(target, sender, listener));
 	}
 
 	public void removeMessageListener(String target, IMMessageListener listener) {
 		this.msgListeners.remove(new MessageListener(target, listener));
 	}
-	
+
 	public void addJoinListener(JoinListener listener) {
 		this.joinListeners.add(listener);
 	}
@@ -226,41 +341,42 @@ public class PircListener extends ListenerAdapter<PircBotX> {
 		this.joinListeners.remove(listener);
 	}
 
-    public void addInviteListener(InviteListener listener) {
-        this.inviteListeners.add(listener);
-    }
+	public void addInviteListener(InviteListener listener) {
+		this.inviteListeners.add(listener);
+	}
 
-    public void removeInviteListener(InviteListener listener) {
-        this.inviteListeners.remove(listener);
-    }
+	public void removeInviteListener(InviteListener listener) {
+		this.inviteListeners.remove(listener);
+	}
 
-    public void addPartListener(PartListener listener) {
-        this.partListeners.add(listener);
-    }
+	public void addPartListener(PartListener listener) {
+		this.partListeners.add(listener);
+	}
 
-    public void removePartListener(PartListener listener) {
-        this.partListeners.remove(listener);
-    }
-	
+	public void removePartListener(PartListener listener) {
+		this.partListeners.remove(listener);
+	}
+
 	private static final class MessageListener {
 		private final String target;
 		private final String sender;
 		private final IMMessageListener listener;
 
-		public MessageListener(String expectedMessageTarget, IMMessageListener listener) {
+		public MessageListener(String expectedMessageTarget,
+				IMMessageListener listener) {
 			this.target = expectedMessageTarget;
 			this.sender = null;
 			this.listener = listener;
 		}
 
-		public MessageListener(String expectedMessageTarget, String expectedMessageSender,
-                IMMessageListener listener) {
-		    this.target = expectedMessageTarget;
-		    this.sender = expectedMessageSender;
-            this.listener = listener;
-        }
+		public MessageListener(String expectedMessageTarget,
+				String expectedMessageSender, IMMessageListener listener) {
+			this.target = expectedMessageTarget;
+			this.sender = expectedMessageSender;
+			this.listener = listener;
+		}
 
-        @Override
+		@Override
 		public int hashCode() {
 			final int prime = 31;
 			int result = 1;
@@ -293,22 +409,16 @@ public class PircListener extends ListenerAdapter<PircBotX> {
 			return true;
 		}
 	}
-	
-	/**
-	 * Removes any IRC special characters (I know of. Where is a authorative guide for them??)
-	 * for the message.
-	 * 
-	 * http://oreilly.com/pub/h/1953
-	 */
+
 	private static String normalize(String ircMessage) {
 		String msg = ircMessage.replace("\u0001", "");
 		msg = msg.replace("\u0002", "");
 		msg = msg.replace("\u0016", "");
 		msg = msg.replace("\u000F", "");
-		
+
 		return msg;
 	}
-	
+
 	public interface JoinListener {
 		/**
 		 * Is called when the ircbot joins a channel.
@@ -316,18 +426,19 @@ public class PircListener extends ListenerAdapter<PircBotX> {
 		void channelJoined(String channelName);
 	}
 
-    public interface InviteListener {
-    	/**
+	public interface InviteListener {
+		/**
 		 * Is called when the ircbot is invited to a channel.
 		 */
-        void inviteReceived(String channelName, String inviter);
-    }
+		void inviteReceived(String channelName, String inviter);
+	}
 
-    public interface PartListener {
-    	/**
-		 * Is called when the ircbot is disconnected (leaves or is kicked) from a channel.
+	public interface PartListener {
+		/**
+		 * Is called when the ircbot is disconnected (leaves or is kicked) from
+		 * a channel.
 		 */
-        void channelParted(String channelName);
-    }
+		void channelParted(String channelName);
+	}
 
 }

--- a/src/test/java/hudson/plugins/ircbot/v2/IRCColorizerTest.java
+++ b/src/test/java/hudson/plugins/ircbot/v2/IRCColorizerTest.java
@@ -1,13 +1,70 @@
 package hudson.plugins.ircbot.v2;
 
+import hudson.model.ResultTrend;
 import static org.junit.Assert.assertEquals;
-
+import static org.junit.Assert.assertTrue;
+import java.util.HashMap;
+import org.fusesource.jansi.Ansi.Color;
 import org.junit.Test;
 import org.jvnet.hudson.test.Bug;
 import org.pircbotx.Colors;
 
 public class IRCColorizerTest {
+	
+	@Test
+	public void changeThemeTest() {
+		assertEquals(IRCColorizer.changeTheme("THEME3"),"THEME3");
+	}
 
+	@Test
+	public void changeThemeTest2() {
+		IRCColorizer.changeTheme("THEME3");
+		assertEquals(IRCColorizer.changeTheme("wut"),"THEME3");
+	}
+
+	@Test
+	public void generateThemeTestOneColor() {
+		String color = "BLUE";
+		HashMap<ResultTrend, String> test = IRCColorizer.oneColorTheme(color);
+		boolean answer = test.get(ResultTrend.FIXED).equals(Colors.BOLD + Colors.UNDERLINE + IRCColors.lookup(color));
+		answer = answer && test.get(ResultTrend.SUCCESS).equals(Colors.BOLD + IRCColors.lookup(color));
+		answer = answer && test.get(ResultTrend.FAILURE).equals(Colors.BOLD + Colors.UNDERLINE + IRCColors.lookup(color));
+		answer = answer && test.get(ResultTrend.STILL_FAILING).equals(Colors.BOLD + IRCColors.lookup(color));
+		answer = answer && test.get(ResultTrend.UNSTABLE).equals(Colors.BOLD + Colors.UNDERLINE + IRCColors.lookup(color));
+		answer = answer && test.get(ResultTrend.STILL_UNSTABLE).equals(Colors.BOLD + IRCColors.lookup(color));
+		answer = answer && test.get(ResultTrend.NOW_UNSTABLE).equals(Colors.BOLD + IRCColors.lookup(color));
+		answer = answer && test.get(ResultTrend.ABORTED).equals(Colors.BOLD + IRCColors.lookup(color));
+		assertTrue(answer);
+	}
+
+	@Test
+	public void generateThemeTestDefault() {
+		HashMap<ResultTrend, String> test = IRCColorizer.createDefault();
+		boolean answer = test.get(ResultTrend.FIXED).equals(Colors.BOLD + Colors.UNDERLINE + Colors.GREEN);
+		answer = answer && test.get(ResultTrend.SUCCESS).equals(Colors.BOLD + Colors.GREEN);
+		answer = answer && test.get(ResultTrend.FAILURE).equals(Colors.BOLD + Colors.UNDERLINE + Colors.RED);
+		answer = answer && test.get(ResultTrend.STILL_FAILING).equals(Colors.BOLD + Colors.RED);
+		answer = answer && test.get(ResultTrend.UNSTABLE).equals(Colors.BOLD + Colors.UNDERLINE + Colors.BROWN);
+		answer = answer && test.get(ResultTrend.STILL_UNSTABLE).equals(Colors.BOLD + Colors.BROWN);
+		answer = answer && test.get(ResultTrend.NOW_UNSTABLE).equals(Colors.BOLD + Colors.MAGENTA);
+		answer = answer && test.get(ResultTrend.ABORTED).equals(Colors.BOLD + Colors.LIGHT_GRAY);
+		assertTrue(answer);
+	}
+
+	@Test
+	public void generateThemeTestTheme2() {
+		HashMap<ResultTrend, String> test = IRCColorizer.theme2();
+		boolean answer = test.get(ResultTrend.FIXED).equals(Colors.BOLD + Colors.UNDERLINE + Colors.BLUE);
+		answer = answer && test.get(ResultTrend.SUCCESS).equals(Colors.BOLD + Colors.BLUE);
+		answer = answer && test.get(ResultTrend.FAILURE).equals(Colors.BOLD + Colors.UNDERLINE + Colors.RED);
+		answer = answer && test.get(ResultTrend.STILL_FAILING).equals(Colors.BOLD + Colors.RED);
+		answer = answer && test.get(ResultTrend.UNSTABLE).equals(Colors.BOLD + Colors.UNDERLINE + Colors.MAGENTA);
+		answer = answer && test.get(ResultTrend.STILL_UNSTABLE).equals(Colors.BOLD + Colors.MAGENTA);
+		answer = answer && test.get(ResultTrend.NOW_UNSTABLE).equals(Colors.BOLD + Colors.RED);
+		answer = answer && test.get(ResultTrend.ABORTED).equals(Colors.BOLD + Colors.BLACK);
+
+		assertTrue(answer);
+	}
 	@Test
 	@Bug(22360)
 	public void shouldColorizeKeywords() {
@@ -17,4 +74,172 @@ public class IRCColorizerTest {
 		assertEquals("Build job123 is " + Colors.BOLD + Colors.RED + "STILL FAILING" + Colors.NORMAL + ": https://server.com/build/42", colorizedMessage);
 	}
 	
+	@Test
+	//Check wether setter function could add new user
+	public void setterTest1()
+	{
+		String nickname = "neverused";
+		IRCColorizer.cleanUserPattern(nickname);
+		int oldSize = IRCColorizer.getSize();
+		String pattern = "Build";
+		String color = "RED";
+		IRCColorizer.setter(nickname, pattern, color);
+		int curSize = IRCColorizer.getSize();
+		assertEquals(oldSize + 1, curSize);
+	}
+	
+	@Test
+	//Check wether setter function could add new pattern->color to a specific user
+	public void setterTest2()
+	{
+		String nickname = "neverused";
+		IRCColorizer.cleanUserPattern(nickname);
+		
+		String pattern1 = "Build";
+		String color1 = "RED";
+		String pattern2 = "[0-9]{3}";
+		String color2 = "BLUE";
+		
+		IRCColorizer.setter(nickname, pattern1, color1);
+		int oldPatternSize = IRCColorizer.getSizeByNickName(nickname);
+
+		IRCColorizer.setter(nickname, pattern2, color2);
+		int curPatternSize = IRCColorizer.getSizeByNickName(nickname);
+		assertEquals(oldPatternSize + 1, curPatternSize);
+	}
+	
+	@Test
+	//Check wether setter function could add an existing pattern->color to a specific user
+	public void setterTest3()
+	{
+		String nickname = "neverused";
+		IRCColorizer.cleanUserPattern(nickname);
+		
+		String pattern1 = "Build";
+		String color1 = "RED";
+		String pattern2 = "Build";
+		String color2 = "BLUE";
+		
+		IRCColorizer.setter(nickname, pattern1, color1);
+		int oldPatternSize = IRCColorizer.getSizeByNickName(nickname);
+
+		IRCColorizer.setter(nickname, pattern2, color2);
+		int curPatternSize = IRCColorizer.getSizeByNickName(nickname);
+		assertEquals(oldPatternSize, curPatternSize);
+	}
+	
+	
+	
+	@Test
+	public void basicColorizeTest() {
+		String nickName = "foo";
+		String pattern = "Build";
+		String color = "RED";
+		
+		String message = "Build job123 is STILL FAILING: https://server.com/build/42";
+		
+		IRCColorizer.setter(nickName, pattern, color);
+		
+		String colorizedMessage = IRCColorizer.colorize(nickName, message);
+		System.out.println(colorizedMessage);
+		assertEquals(Colors.RED + "Build" + Colors.NORMAL + " job123 is STILL FAILING: https://server.com/build/42", colorizedMessage);
+	}
+	
+	@Test
+	public void duplicateColorizeTest() {
+		String nickName = "foo";
+		String pattern = "Build";
+		String color = "RED";
+		
+		String message = "Build job123 is STILL FAILING: https://server.com/Build/42";
+		
+		IRCColorizer.setter(nickName, pattern, color);
+		
+		String colorizedMessage = IRCColorizer.colorize(nickName, message);
+//		System.out.println(colorizedMessage);
+		assertEquals(Colors.RED + "Build" + Colors.NORMAL + " job123 is STILL FAILING: https://server.com/"+
+				Colors.RED + "Build" + Colors.NORMAL + "/42", colorizedMessage);
+	}
+	
+	@Test
+	public void duplicateNewLineColorizeTest() {
+		String nickName = "foo";
+		String pattern = "Build";
+		String color = "RED\n";
+		
+		String message = "Build job123 is STILL FAILING: https://server.com/Build/42";
+		
+		IRCColorizer.setter(nickName, pattern, color);
+		
+		String colorizedMessage = IRCColorizer.colorize(nickName, message);
+//		System.out.println(colorizedMessage);
+		assertEquals(Colors.RED + "Build" + Colors.NORMAL + " job123 is STILL FAILING: https://server.com/"+
+				Colors.RED + "Build" + Colors.NORMAL + "/42", colorizedMessage);
+	}
+	
+	@Test
+	public void regexSimpleMatch1()
+	{
+
+		String nickName = "foo2";
+		String pattern = "B[a-z]*d";
+		String color = "RED\n";
+		String message = "Build job123 is STILL FAILING: https://server.com/Bird/Build/42";
+		IRCColorizer.setter(nickName, pattern, color);
+		String colorizedMessage = IRCColorizer.colorize(nickName, message);
+		assertEquals(Colors.RED + "Build" + Colors.NORMAL + " job123 is STILL FAILING: https://server.com/"+
+		Colors.RED + "Bird" + Colors.NORMAL + "/" + Colors.RED + "Build" + Colors.NORMAL + "/42", colorizedMessage);
+
+	}
+	
+	@Test
+	public void regexMultipleColorsTest()
+	{
+
+		String nickName = "foo6";
+		String pattern1 = "B[a-z]*d";
+		String color1 = "RED\n";
+		
+		String pattern2 = "[0-9]{3}";
+		String color2 = "BLUE\n";
+		
+		String message = "Build job123 is STILL FAILING: https://server.com/Bird/Build/42";
+		IRCColorizer.setter(nickName, pattern1, color1);
+		IRCColorizer.setter(nickName, pattern2, color2);
+		String colorizedMessage = IRCColorizer.colorize(nickName, message);
+		//assertEquals(Colors.RED + "Build" + Colors.NORMAL + " job123 is STILL FAILING: https://server.com/"+
+		//		Colors.RED + "Bird" + Colors.NORMAL + "/" + Colors.RED + "Build" + Colors.NORMAL + "/42", colorizedMessage);
+
+		
+		assertEquals(Colors.RED + "Build" + Colors.NORMAL + " job" + Colors.BLUE + "123" + Colors.NORMAL + " is STILL FAILING: https://server.com/"+
+		Colors.RED + "Bird" + Colors.NORMAL + "/" + Colors.RED + "Build" + Colors.NORMAL + "/42", colorizedMessage);
+
+	}
+	
+	@Test
+	public void regexMultipleUserDifferentColorTest()
+	{
+
+		String nickName1 = "A";
+		String pattern1 = "B[a-z]*d";
+		String color1 = "RED\n";
+		
+		String nickName2 = "B";
+		String pattern2 = "B[a-z]*d";
+		String color2 = "BLUE\n";
+		
+		String message = "Build job123 is STILL FAILING: https://server.com/Bird/Build/42";
+		
+		IRCColorizer.setter(nickName1, pattern1, color1);
+		IRCColorizer.setter(nickName2, pattern2, color2);
+		
+		String colorizedMessage1 = IRCColorizer.colorize(nickName1, message);
+		String colorizedMessage2 = IRCColorizer.colorize(nickName2, message);
+		
+		assertEquals(Colors.RED + "Build" + Colors.NORMAL + " job123 is STILL FAILING: https://server.com/"+
+				Colors.RED + "Bird" + Colors.NORMAL + "/" + Colors.RED + "Build" + Colors.NORMAL + "/42", colorizedMessage1);
+		assertEquals(Colors.BLUE + "Build" + Colors.NORMAL + " job123 is STILL FAILING: https://server.com/"+
+				Colors.BLUE + "Bird" + Colors.NORMAL + "/" + Colors.BLUE + "Build" + Colors.NORMAL + "/42", colorizedMessage2);
+
+	}
 }

--- a/src/test/java/hudson/plugins/ircbot/v2/PircListenerTest.java
+++ b/src/test/java/hudson/plugins/ircbot/v2/PircListenerTest.java
@@ -1,0 +1,78 @@
+package hudson.plugins.ircbot.v2;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+
+
+public class PircListenerTest {
+	
+	private String msg = "!jenkins 112843667904431 only rtfreed2,sdavis18 ,  mickeymouse";
+	private String dupedArgs = "!jenkins 112843667904431 only sdavis18,sdavis18,sdavis18";
+	private String multiArgMsg = "!jenkins asdf qwerty wut,a,a,a,a|a|rtfreed2|   |  only sdavis18,minniemouse";
+	
+	//regular message parsing
+	@Test
+	public void getMultiMessageTest() {
+		String msgExpected = "!jenkins 112843667904431 ";
+		String multiMsg = PircListener.getMultiMessage(msg);
+		
+		assertEquals(msgExpected, multiMsg);
+	}
+	
+	//regular recipient parsing
+	@Test
+	public void getRecipientsTest() {
+		LinkedHashSet<String> users = new LinkedHashSet<String>(Arrays.asList("rtfreed2", "sdavis18", "mickeymouse"));
+		LinkedHashSet<String> recipients = PircListener.getRecipients(msg, "");
+		
+		assertEquals(users, recipients);
+	}
+	
+	//parsing recipients with multiple arguments to the command
+	//also tests sender versus recipient functionality
+	@Test
+	public void getMultiArgRecipientTest(){
+		LinkedHashSet<String> users = new LinkedHashSet<String>(Arrays.asList("sdavis18", "minniemouse"));
+		LinkedHashSet<String> recipients = PircListener.getRecipients(multiArgMsg, "rtfreed2");
+		assertEquals(users,recipients);
+	}
+	
+	//parsing message with multiple arguments to the command
+	@Test
+	public void getMultiArgMessageTest(){
+		String msgExpected = "!jenkins asdf qwerty wut,a,a,a,a|a|rtfreed2|   |  ";
+		String multiMsg = PircListener.getMultiMessage(multiArgMsg);
+		
+		assertEquals(msgExpected, multiMsg);
+	}
+	
+	//parsing message with no arguments, will generate a warning in console
+	@Test
+	public void getRecipientsNoArgsTest() {
+		String noArgs = "!jenkins 112843667904431 only";
+		LinkedHashSet<String> recipients = PircListener.getRecipients(noArgs, "");
+		
+		assertTrue(recipients.isEmpty());
+	}
+	
+	//parsing recipients with duplicated users
+	@Test
+	public void getRecipientsDeDupeTest() {
+		LinkedHashSet<String> recipients = PircListener.getRecipients(dupedArgs, "");
+		
+		assertEquals(recipients.size(), 1);
+	}
+	
+	//parsing recipients with duplicated users AND testing sender vs recipient cross-checking
+	@Test
+	public void getRecipientsDeDupeNoUserTest() {
+		LinkedHashSet<String> recipients = PircListener.getRecipients(dupedArgs, "sdavis18");
+		
+		assertEquals(recipients.size(), 0);
+	}
+}


### PR DESCRIPTION
Adding two new features to the plugin (tests and javadoc included)
#### Scope of Notifications
- send a command to jenkins, along with some usernames. The reply will be private messages to the usernames you passed through (instead of to the public channel)
- syntax is `!jenkins botsnack bugs only scttdavs, foo, bar` would return private messages to scttdavs, foo and bar.
#### Custom Colorizor Colors
- set custom colors for regex patterns (that you pass through) and save them as a setting only for the user that set it. 
- can also clear a previous setting
- syntax is `!jenkins set color <pattern> BLUE` and to clear `!jenkins set color <pattern> CLEAR`
- so any future messages that contain a match for `<pattern>` will now be blue.
- great for overriding current colors for `FAILURE` and `SUCCESS` (for example)
