### PR TITLE
Table-to-Div migration: first shot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <gitHubRepo>jenkinsci/ircbot-plugin</gitHubRepo>
         <version.instant-messaging.plugin>1.39</version.instant-messaging.plugin>
         <java.level>8</java.level>
-        <jenkins.version>2.204.6</jenkins.version>
+        <jenkins.version>2.269</jenkins.version>
     </properties>
 
     <dependencyManagement>

--- a/src/main/resources/hudson/plugins/ircbot/IrcNotifyStep/config.jelly
+++ b/src/main/resources/hudson/plugins/ircbot/IrcNotifyStep/config.jelly
@@ -8,20 +8,21 @@
       <f:entry title="Channels"
               description="Channels to notify. Name and optional password. Check 'Notification only' if you want to disallow bot commands."
               help="/plugin/ircbot/help-instanceConfigChannels.html">
-          <table width="100%">
-              <tr style="text-align:left"><th width="30%">Name</th><th width="30%">Password</th><th width="10%">Notification only</th><th width="30%"/></tr>
-          </table>
           <f:repeatable name="irc_publisher.channels" var="ch" items="${instance.notificationTargets}">
-            <table width="100%">
-                <tr>
-                    <td width="30%"><input type="text" width="100%" style="text-align:left" name="irc_publisher.channel.name" value="${ch.name}" /></td>
-                    <td width="30%"><input type="password" width="100%" style="text-align:left" name="irc_publisher.channel.password" value="${ch.password}" /></td>
-                    <td width="10%"><f:checkbox name="irc_publisher.chat.notificationOnly" checked="${ch.notificationOnly}"/></td>
-                    <td width="30%">
-                        <div align="right"><f:repeatableDeleteButton /></div>
-                    </td>
-                </tr>
-            </table>
+            <div width="100%">
+              <f:entry title="Name">
+                  <input type="text" width="100%" style="text-align:left" name="irc_publisher.channel.name" value="${ch.name}" />
+              </f:entry>
+              <f:entry title="Password">
+                  <input type="password" width="100%" style="text-align:left" name="irc_publisher.channel.password" value="${ch.password}" />
+              </f:entry>
+              <f:entry title="Notification only">
+                  <f:checkbox name="irc_publisher.chat.notificationOnly" checked="${ch.notificationOnly}"/>
+              </f:entry>
+              <f:entry>
+                  <div align="right"><f:repeatableDeleteButton /></div>
+              </f:entry>
+            </div>
           </f:repeatable>
       </f:entry>
 

--- a/src/main/resources/hudson/plugins/ircbot/IrcNotifyStep/global.jelly
+++ b/src/main/resources/hudson/plugins/ircbot/IrcNotifyStep/global.jelly
@@ -25,22 +25,21 @@
     <f:entry title="Channels"
         description="Channels to join. Name and optional password. Check 'Notification only' if you want to disallow bot commands."
         help="/plugin/ircbot/help-globalConfigChannels.html">
-      <!-- Note that this strange separation of the table headers into a separate table is done one purpose. I didn't find another way
-                  without breaking the rendering of the whole config page! -->
-     <table width="100%">
-       <tr style="text-align:left"><th width="30%">Name</th><th width="30%">Password</th><th width="10%">Notification only</th><th width="30%"/></tr>
-     </table>
      <f:repeatable name="irc_publisher.channels" var="ch" items="${descriptor.defaultTargets}">
-        <table width="100%">
-            <tr>
-                    <td width="30%"><input type="text" width="100%" style="text-align:left" name="irc_publisher.channel.name" value="${ch.name}" /></td>
-                    <td width="30%"><input type="password" width="100%" style="text-align:left" name="irc_publisher.channel.password" value="${ch.password}" /></td>
-                    <td width="10%"><f:checkbox name="irc_publisher.chat.notificationOnly" checked="${ch.notificationOnly}"/></td>
-                    <td width="30%">
-                        <div align="right"><f:repeatableDeleteButton /></div>
-                    </td>
-            </tr>
-        </table>
+            <div width="100%">
+              <f:entry title="Name">
+                  <input type="text" width="100%" style="text-align:left" name="irc_publisher.channel.name" value="${ch.name}" />
+              </f:entry>
+              <f:entry title="Password">
+                  <input type="password" width="100%" style="text-align:left" name="irc_publisher.channel.password" value="${ch.password}" />
+              </f:entry>
+              <f:entry title="Notification only">
+                  <f:checkbox name="irc_publisher.chat.notificationOnly" checked="${ch.notificationOnly}"/>
+              </f:entry>
+              <f:entry>
+                  <div align="right"><f:repeatableDeleteButton /></div>
+              </f:entry>
+            </div>
      </f:repeatable>
     </f:entry>
     <f:advanced>

--- a/src/main/resources/hudson/plugins/ircbot/IrcPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/ircbot/IrcPublisher/config.jelly
@@ -8,20 +8,21 @@
       <f:entry title="Channels"
               description="Channels to notify. Name and optional password. Check 'Notification only' if you want to disallow bot commands."
               help="/plugin/ircbot/help-instanceConfigChannels.html">
-          <table width="100%">
-              <tr style="text-align:left"><th width="30%">Name</th><th width="30%">Password</th><th width="10%">Notification only</th><th width="30%"/></tr>
-          </table>
           <f:repeatable name="irc_publisher.channels" var="ch" items="${instance.notificationTargets}">
-            <table width="100%">
-                <tr>
-                    <td width="30%"><input type="text" width="100%" style="text-align:left" name="irc_publisher.channel.name" value="${ch.name}" /></td>
-                    <td width="30%"><input type="password" width="100%" style="text-align:left" name="irc_publisher.channel.password" value="${ch.password}" /></td>
-                    <td width="10%"><f:checkbox name="irc_publisher.chat.notificationOnly" checked="${ch.notificationOnly}"/></td>
-                    <td width="30%">
-                        <div align="right"><f:repeatableDeleteButton /></div>
-                    </td>
-                </tr>
-            </table>
+            <div width="100%">
+              <f:entry title="Name">
+                  <input type="text" width="100%" style="text-align:left" name="irc_publisher.channel.name" value="${ch.name}" />
+              </f:entry>
+              <f:entry title="Password">
+                  <input type="password" width="100%" style="text-align:left" name="irc_publisher.channel.password" value="${ch.password}" />
+              </f:entry>
+              <f:entry title="Notification only">
+                  <f:checkbox name="irc_publisher.chat.notificationOnly" checked="${ch.notificationOnly}"/>
+              </f:entry>
+              <f:entry>
+                  <div align="right"><f:repeatableDeleteButton /></div>
+              </f:entry>
+            </div>
           </f:repeatable>
       </f:entry>
 

--- a/src/main/resources/hudson/plugins/ircbot/IrcPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/ircbot/IrcPublisher/global.jelly
@@ -25,22 +25,21 @@
     <f:entry title="Channels"
         description="Channels to join. Name and optional password. Check 'Notification only' if you want to disallow bot commands."
         help="/plugin/ircbot/help-globalConfigChannels.html">
-      <!-- Note that this strange separation of the table headers into a separate table is done one purpose. I didn't find another way
-                  without breaking the rendering of the whole config page! -->
-     <table width="100%">
-       <tr style="text-align:left"><th width="30%">Name</th><th width="30%">Password</th><th width="10%">Notification only</th><th width="30%"/></tr>
-     </table>
      <f:repeatable name="irc_publisher.channels" var="ch" items="${descriptor.defaultTargets}">
-        <table width="100%">
-            <tr>
-                    <td width="30%"><input type="text" width="100%" style="text-align:left" name="irc_publisher.channel.name" value="${ch.name}" /></td>
-                    <td width="30%"><input type="password" width="100%" style="text-align:left" name="irc_publisher.channel.password" value="${ch.password}" /></td>
-                    <td width="10%"><f:checkbox name="irc_publisher.chat.notificationOnly" checked="${ch.notificationOnly}"/></td>
-                    <td width="30%">
-                        <div align="right"><f:repeatableDeleteButton /></div>
-                    </td>
-            </tr>
-        </table>
+        <div width="100%">
+            <f:entry title="Name">
+                <input type="text" width="100%" style="text-align:left" name="irc_publisher.channel.name" value="${ch.name}" />
+            </f:entry>
+            <f:entry title="Password">
+                <input type="password" width="100%" style="text-align:left" name="irc_publisher.channel.password" value="${ch.password}" />
+            </f:entry>
+            <f:entry title="Notification only">
+                <f:checkbox name="irc_publisher.chat.notificationOnly" checked="${ch.notificationOnly}"/>
+            </f:entry>
+            <f:entry>
+                <div align="right"><f:repeatableDeleteButton /></div>
+            </f:entry>
+        </div>
      </f:repeatable>
     </f:entry>
     <f:advanced>


### PR DESCRIPTION
Follow examples from https://www.jenkins.io/doc/developer/views/table-to-div-migration/
and https://github.com/jenkinsci/http-request-plugin/blob/master/src/main/resources/jenkins/plugins/http_request/HttpRequestGlobalConfig/config.jelly
among other influences, to replace hardcoded table/tr/td markup with something that
feels equivalent in Jelly.

Disclaimer: no idea about the syntax and nuances ;)

Possible later improvement: replace <input> elements with some jelly tags,
but the examples I've seen left theirs in place too - so maybe they are not
fatally toxic so far.

Probably https://issues.jenkins.io/browse/JENKINS-64089 describes the same problem.