### PR TITLE
SECURITY-829 + fixing form usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <revision>2.34</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/ircbot-plugin</gitHubRepo>
-    <version.instant-messaging.plugin>1.40-SNAPSHOT</version.instant-messaging.plugin>
+    <version.instant-messaging.plugin>1.40-rc459.252399e42dd7</version.instant-messaging.plugin>
     <java.level>8</java.level>
     <jenkins.version>2.269</jenkins.version>
   </properties>
@@ -58,12 +58,28 @@
       <artifactId>pircbotx</artifactId>
       <version>2.0.1</version>
       <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>annotations</artifactId>
-      <version>3.0.0</version>
-      <scope>provided</scope>
+      <exclusions>
+        <!-- provides an ancient version, junit plugin is pulling in a more recent one -->
+        <exclusion>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+        </exclusion>
+        <!-- provided by jenkins core -->
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <!-- provided by jenkins core -->
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+        <!-- provided by jenkins core -->
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,8 +6,9 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.12</version>
+    <version>4.13</version>
   </parent>
+  <groupId>org.jvnet.hudson.plugins</groupId>
   <artifactId>ircbot</artifactId>
   <packaging>hpi</packaging>
   <version>${revision}${changelist}</version>
@@ -25,7 +26,7 @@
     <revision>2.34</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/ircbot-plugin</gitHubRepo>
-    <version.instant-messaging.plugin>1.38</version.instant-messaging.plugin>
+    <version.instant-messaging.plugin>1.40-SNAPSHOT</version.instant-messaging.plugin>
     <java.level>8</java.level>
     <jenkins.version>2.269</jenkins.version>
   </properties>
@@ -34,8 +35,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.204.x</artifactId>
-        <version>17</version>
+        <artifactId>bom-2.263.x</artifactId>
+        <version>18</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <gitHubRepo>jenkinsci/ircbot-plugin</gitHubRepo>
     <version.instant-messaging.plugin>1.38</version.instant-messaging.plugin>
     <java.level>8</java.level>
-    <jenkins.version>2.204.6</jenkins.version>
+    <jenkins.version>2.269</jenkins.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <revision>2.36</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/ircbot-plugin</gitHubRepo>
-        <version.instant-messaging.plugin>1.40-rc459.252399e42dd7</version.instant-messaging.plugin>
+        <version.instant-messaging.plugin>1.40-rc463.9504a33d367e</version.instant-messaging.plugin>
         <java.level>8</java.level>
         <jenkins.version>2.269</jenkins.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -1,149 +1,155 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- $Id: pom.xml 39481 2011-05-12 20:14:54Z kutzi $ -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.jenkins-ci.plugins</groupId>
-    <artifactId>plugin</artifactId>
-    <version>4.13</version>
-  </parent>
-  <groupId>org.jvnet.hudson.plugins</groupId>
-  <artifactId>ircbot</artifactId>
-  <packaging>hpi</packaging>
-  <version>${revision}${changelist}</version>
-  <name>Jenkins IRC Plugin</name>
-  <description>A build status publisher that notifies channels on a IRC server</description>
-  <url>https://github.com/jenkinsci/ircbot-plugin</url>
-  <licenses>
-    <license>
-        <name>MIT license</name>
-        <comments>All source code is under the MIT license.</comments>
-    </license>
-  </licenses>
+    <parent>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>plugin</artifactId>
+        <version>4.13</version>
+    </parent>
+    <groupId>org.jvnet.hudson.plugins</groupId>
+    <artifactId>ircbot</artifactId>
+    <packaging>hpi</packaging>
+    <version>${revision}${changelist}</version>
+    <name>Jenkins IRC Plugin</name>
+    <description>A build status publisher that notifies channels on a IRC server</description>
+    <url>https://github.com/jenkinsci/ircbot-plugin</url>
+    <licenses>
+        <license>
+            <name>MIT license</name>
+            <comments>All source code is under the MIT license.</comments>
+        </license>
+    </licenses>
 
-  <properties>
-    <revision>2.34</revision>
-    <changelist>-SNAPSHOT</changelist>
-    <gitHubRepo>jenkinsci/ircbot-plugin</gitHubRepo>
-    <version.instant-messaging.plugin>1.40-rc459.252399e42dd7</version.instant-messaging.plugin>
-    <java.level>8</java.level>
-    <jenkins.version>2.269</jenkins.version>
-  </properties>
+    <properties>
+        <revision>2.36</revision>
+        <changelist>-SNAPSHOT</changelist>
+        <gitHubRepo>jenkinsci/ircbot-plugin</gitHubRepo>
+        <version.instant-messaging.plugin>1.40-rc459.252399e42dd7</version.instant-messaging.plugin>
+        <java.level>8</java.level>
+        <jenkins.version>2.269</jenkins.version>
+    </properties>
 
-  <dependencyManagement>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.263.x</artifactId>
+                <version>18</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
-      <dependency>
-        <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.263.x</artifactId>
-        <version>18</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
+        <dependency>
+            <groupId>org.jvnet.hudson.plugins</groupId>
+            <artifactId>instant-messaging</artifactId>
+            <version>${version.instant-messaging.plugin}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.pircbotx</groupId>
+            <artifactId>pircbotx</artifactId>
+            <version>2.0.1</version>
+            <scope>compile</scope>
+            <exclusions>
+                <!-- provides an ancient version, junit plugin is pulling in a more recent one -->
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+                <!-- provided by jenkins core -->
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <!-- provided by jenkins core -->
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+                <!-- provided by jenkins core -->
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
-  </dependencyManagement>
-  
-  <dependencies>
-    <dependency>
-        <groupId>org.jvnet.hudson.plugins</groupId>
-        <artifactId>instant-messaging</artifactId>
-        <version>${version.instant-messaging.plugin}</version>
-    </dependency>
-    <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-step-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.pircbotx</groupId>
-      <artifactId>pircbotx</artifactId>
-      <version>2.0.1</version>
-      <scope>compile</scope>
-      <exclusions>
-        <!-- provides an ancient version, junit plugin is pulling in a more recent one -->
-        <exclusion>
-          <groupId>org.apache.commons</groupId>
-          <artifactId>commons-lang3</artifactId>
-        </exclusion>
-        <!-- provided by jenkins core -->
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-        <!-- provided by jenkins core -->
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-        <!-- provided by jenkins core -->
-        <exclusion>
-          <groupId>commons-codec</groupId>
-          <artifactId>commons-codec</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-  </dependencies>
 
-  <repositories>
-    <repository>
-        <id>repo.jenkins-ci.org</id>
-        <url>https://repo.jenkins-ci.org/public/</url>
-    </repository>
-    <repository>
-        <id>jenkins-snapshots</id>
-        <url>https://repo.jenkins-ci.org/content/repositories/snapshots</url>
-        <snapshots>
-          <enabled>true</enabled>
-        </snapshots>
-    </repository>
-  </repositories>
+    <repositories>
+        <repository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </repository>
+        <repository>
+            <id>jenkins-snapshots</id>
+            <url>https://repo.jenkins-ci.org/content/repositories/snapshots</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
-  <developers>
-    <developer>
-        <id>kutzi</id>
-        <name>Christoph Kutzinski</name>
-        <email>kutzi@gmx.de</email>
-        <timezone>1</timezone>
-    </developer>
-  </developers>
+    <developers>
+        <developer>
+            <id>jimklimov</id>
+            <name>Jim Klimov</name>
+            <email>jimklimov+jenkinsci@gmail.com</email>
+            <timezone>1</timezone>
+        </developer>
+        <developer>
+            <id>kutzi</id>
+            <name>Christoph Kutzinski</name>
+            <email>kutzi@gmx.de</email>
+            <timezone>1</timezone>
+        </developer>
+    </developers>
 
-  <scm>
-    <connection>scm:git:github.com:${gitHubRepo}.git</connection>
-    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-    <url>https://github.com/${gitHubRepo}</url>
-    <tag>${scmTag}</tag>
-  </scm>
+    <scm>
+        <connection>scm:git:github.com:${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
+        <tag>${scmTag}</tag>
+    </scm>
 
-  <pluginRepositories>
-    <pluginRepository>
-        <id>repo.jenkins-ci.org</id>
-        <url>https://repo.jenkins-ci.org/public/</url>
-    </pluginRepository>
-  </pluginRepositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>repo.jenkins-ci.org</id>
+            <url>https://repo.jenkins-ci.org/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
 
-  <build>
-    <plugins>
-      <plugin>
-         <artifactId>maven-checkstyle-plugin</artifactId>
-         <version>3.0.0</version>
-         <configuration>
-           <configLocation>${basedir}/checkstyle.xml</configLocation>
-           <includeTestSourceDirectory>true</includeTestSourceDirectory>
-           <sourceDirectories>
-             <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
-           </sourceDirectories>
-           <testSourceDirectories>
-             <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
-           </testSourceDirectories>
-         </configuration>
-         <executions>
-           <execution>
-             <goals>
-               <goal>check</goal>
-             </goals>
-           </execution>
-         </executions>
-      </plugin>
-    </plugins>
-  </build>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <configLocation>${basedir}/checkstyle.xml</configLocation>
+                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    <sourceDirectories>
+                        <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+                    </sourceDirectories>
+                    <testSourceDirectories>
+                        <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
+                    </testSourceDirectories>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
+++ b/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
@@ -142,9 +142,6 @@ public class IrcPublisher extends IMPublisher {
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> implements IMPublisherDescriptor {
 
         private static final String PREFIX = "irc_publisher.";
-        public static final String PARAMETERNAME_USE_NOTICE = PREFIX + "useNotice";
-        public static final String PARAMETERNAME_USE_COLORS = PREFIX + "useColors";
-        public static final String PARAMETERNAME_NICKSERV_PASSWORD = PREFIX + "nickServPassword";
 
         public static final String[] CHARSETS;
 
@@ -175,6 +172,7 @@ public class IrcPublisher extends IMPublisher {
 
         private boolean sslTrustAllCertificates;
 
+        @Deprecated
         String password = null;
         Secret secretPassword;
 
@@ -182,6 +180,7 @@ public class IrcPublisher extends IMPublisher {
 
         String nick = "jenkins-bot";
 
+        @Deprecated
         String nickServPassword = null;
         Secret secretNickServPassword;
 
@@ -210,7 +209,7 @@ public class IrcPublisher extends IMPublisher {
         private String charset;
 
         private boolean useColors;
-
+        
         DescriptorImpl() {
             super(IrcPublisher.class);
             load();
@@ -250,58 +249,15 @@ public class IrcPublisher extends IMPublisher {
                     || "true".equals(req.getParameter("irc_publisher.enabled"));
             if (this.enabled) {
                 JSONObject enabled = formData.getJSONObject("enabled");
-                this.hostname = enabled.getString("hostname");
-                this.login = enabled.getString("login");
-                this.secretPassword = Secret.fromString(enabled.getString("secretPassword"));
-                this.sasl = enabled.getBoolean("sasl");
-                this.nick = enabled.getString("nick");
-                this.secretNickServPassword = Secret.fromString(enabled.getString("secretNickServPassword"));
-                this.port = enabled.getInt("port");
-
-                this.socksHost = enabled.getString("socksHost");
-                this.socksPort = enabled.getInt("socksPort");
-                this.ssl = enabled.getBoolean("ssl");
-                this.sslTrustAllCertificates = enabled.getBoolean("sslTrustAllCertificates");
-                this.commandPrefix = Util.fixEmptyAndTrim(enabled.getString("commandPrefix"));
-
-                this.disallowPrivateChat = enabled.getBoolean("disallowPrivateChat");
-
-                this.messageRate = getMessageRateFromSystemProperty();
-
-                List<IMMessageTarget> targets = new ArrayList<>();
-                // JENKINS-13697: Get the data from the JSON representation which always returns
-                // a value. The downside is that we are dependent on the data structure.
-                JSONArray jchans;
-                jchans = enabled.getJSONArray("defaultTargets");
-
-                for (int i = 0; i < jchans.size(); i++) {
-                    JSONObject channel = jchans.getJSONObject(i);
-                    String name = channel.getString("name");
-                    if (Util.fixEmptyAndTrim(name) == null) {
-                        throw new FormException("Channel name must not be empty", "channel.name");
-                    }
-                    Secret password = Secret.fromString(channel.getString("secretPassword"));
-                    boolean notificationOnly = channel.getBoolean("notificationOnly");
-
-                    targets.add(new GroupChatIMMessageTarget(name, password, notificationOnly));
-                }
-                this.defaultTargets = targets;
-
-                this.hudsonLogin = req.getParameter(getParamNames().getJenkinsLogin());
-
-                this.useNotice = "on".equals(req.getParameter(PARAMETERNAME_USE_NOTICE));
-
-                this.charset = req.getParameter("irc_publisher.charset");
-
-                this.useColors = "on".equals(req.getParameter(PARAMETERNAME_USE_COLORS));
+                req.bindJSON(this, enabled);
 
                 // try to establish the connection
-//                try {
-//                    IRCConnectionProvider.setDesc(this);
-//                    IRCConnectionProvider.getInstance().currentConnection();
-//                } catch (final Exception e) {
-//                    LOGGER.warning(ExceptionHelper.dump(e));
-//                }
+                try {
+                    IRCConnectionProvider.setDesc(this);
+                    IRCConnectionProvider.getInstance().currentConnection();
+                } catch (final Exception e) {
+                    LOGGER.warning(ExceptionHelper.dump(e));
+                }
             } else {
                 IRCConnectionProvider.getInstance().releaseConnection();
                 try {
@@ -346,7 +302,7 @@ public class IrcPublisher extends IMPublisher {
                 if (Util.fixEmptyAndTrim(name) == null) {
                     throw new FormException("Channel name must not be empty", "channel.name");
                 }
-                String password = Secret.fromString(channel.getString("secretPassword")).getPlainText();
+                Secret password = Secret.fromString(channel.getString("secretPassword"));
                 boolean notificationOnly = channel.getBoolean("notificationOnly");
 
                 targets.add(new GroupChatIMMessageTarget(name, password, notificationOnly));
@@ -514,6 +470,95 @@ public class IrcPublisher extends IMPublisher {
             return this.defaultTargets;
         }
 
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public void setHostname(String hostname) {
+            this.hostname = hostname;
+        }
+
+        public void setPort(Integer port) {
+            this.port = port;
+        }
+
+        public void setSsl(boolean ssl) {
+            this.ssl = ssl;
+        }
+
+        public void setDisallowPrivateChat(boolean disallowPrivateChat) {
+            this.disallowPrivateChat = disallowPrivateChat;
+        }
+
+        public void setLogin(String login) {
+            this.login = login;
+        }
+
+        public boolean isSslTrustAllCertificates() {
+            return sslTrustAllCertificates;
+        }
+
+        public void setSslTrustAllCertificates(boolean sslTrustAllCertificates) {
+            this.sslTrustAllCertificates = sslTrustAllCertificates;
+        }
+
+        public void setSecretPassword(Secret secretPassword) {
+            this.secretPassword = secretPassword;
+        }
+
+        public void setSasl(boolean sasl) {
+            this.sasl = sasl;
+        }
+
+        public void setNick(String nick) {
+            this.nick = nick;
+        }
+
+        public void setSecretNickServPassword(Secret secretNickServPassword) {
+            this.secretNickServPassword = secretNickServPassword;
+        }
+
+        public void setSocksHost(String socksHost) {
+            this.socksHost = socksHost;
+        }
+
+        public void setSocksPort(Integer socksPort) {
+            this.socksPort = socksPort;
+        }
+
+        public void setMessageRate(Integer messageRate) {
+            this.messageRate = messageRate;
+        }
+
+        public void setDefaultTargets(List<IMMessageTarget> defaultTargets) {
+            this.defaultTargets = defaultTargets;
+        }
+
+        public void setCommandPrefix(String commandPrefix) {
+            this.commandPrefix = commandPrefix;
+        }
+
+        public String getHudsonLogin() {
+            return hudsonLogin;
+        }
+
+        public void setHudsonLogin(String hudsonLogin) {
+            this.hudsonLogin = hudsonLogin;
+        }
+
+        public void setUseNotice(boolean useNotice) {
+            this.useNotice = useNotice;
+        }
+
+        public void setCharset(String charset) {
+            this.charset = charset;
+        }
+
+        public void setUseColors(boolean useColors) {
+            this.useColors = useColors;
+        }
+        
         //@Override
         public IMMessageTargetConverter getIMMessageTargetConverter() {
             return CONVERTER;

--- a/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
+++ b/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
@@ -172,7 +172,7 @@ public class IrcPublisher extends IMPublisher {
         private boolean sslTrustAllCertificates;
 
         @Deprecated
-        String password = null;
+        transient String password = null;
         Secret secretPassword;
 
         private boolean sasl;
@@ -180,7 +180,7 @@ public class IrcPublisher extends IMPublisher {
         String nick = "jenkins-bot";
 
         @Deprecated
-        String nickServPassword = null;
+        transient String nickServPassword = null;
         Secret secretNickServPassword;
 
         private String socksHost = null;

--- a/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
+++ b/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
@@ -24,7 +24,6 @@ import hudson.plugins.im.tools.ExceptionHelper;
 import hudson.plugins.ircbot.v2.IRCConnectionProvider;
 import hudson.plugins.ircbot.v2.IRCMessageTargetConverter;
 import hudson.tasks.BuildStepDescriptor;
-//import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 
 import hudson.util.Scrambler;
@@ -209,7 +208,7 @@ public class IrcPublisher extends IMPublisher {
         private String charset;
 
         private boolean useColors;
-        
+
         DescriptorImpl() {
             super(IrcPublisher.class);
             load();
@@ -374,7 +373,7 @@ public class IrcPublisher extends IMPublisher {
         /**
          * @return The password that should be used to try and identify
          * with NickServ.
-         * 
+         *
          * @deprecated use {@link #getSecretNickServPassword()}
          */
         @Deprecated
@@ -558,7 +557,7 @@ public class IrcPublisher extends IMPublisher {
         public void setUseColors(boolean useColors) {
             this.useColors = useColors;
         }
-        
+
         //@Override
         public IMMessageTargetConverter getIMMessageTargetConverter() {
             return CONVERTER;

--- a/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
+++ b/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
@@ -311,7 +311,7 @@ public class IrcPublisher extends IMPublisher {
                 } else {
                     // if only one channel then it comes as an object
                     JSONObject notificationTarget = formData.getJSONObject("notificationTargets");
-                  
+
                     String name = notificationTarget.getString("name");
                     if (Util.fixEmptyAndTrim(name) == null) {
                         throw new FormException("Channel name must not be empty", "channel.name");

--- a/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
+++ b/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
@@ -494,7 +494,7 @@ public class IrcPublisher extends IMPublisher {
             this.hostname = hostname;
         }
 
-        public void setPort(Integer port) {
+        public void setPort(int port) {
             this.port = port;
         }
 

--- a/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
+++ b/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
@@ -104,13 +104,17 @@ public class IRCConnection implements IMConnection, JoinListener, InviteListener
         } else {
             if (this.descriptor.getSecretPassword() != null) {
                 String password = Util.fixEmpty(this.descriptor.getSecretPassword().getPlainText());
-                config.setServerPassword(password);
+                if (password != null) {
+                    config.setServerPassword(password);
+                }
             }
         }
 
         if (this.descriptor.getSecretNickServPassword() != null) {
             final String nickServPassword = Util.fixEmpty(this.descriptor.getSecretNickServPassword().getPlainText());
-            config.setNickservPassword(nickServPassword);
+            if (nickServPassword != null) {
+                config.setNickservPassword(nickServPassword);
+            }
         }
 
 

--- a/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
+++ b/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
@@ -343,7 +343,7 @@ public class IRCConnection implements IMConnection, JoinListener, InviteListener
         LOGGER.info("Trying to join channel " + channel.getName());
 
         if (channel.hasPassword()) {
-            this.pircConnection.sendIRC().joinChannel(channel.getName(), channel.getPassword());
+            this.pircConnection.sendIRC().joinChannel(channel.getName(), channel.getSecretPassword().getPlainText());
         } else {
             this.pircConnection.sendIRC().joinChannel(channel.getName());
         }

--- a/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
+++ b/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
@@ -102,11 +102,16 @@ public class IRCConnection implements IMConnection, JoinListener, InviteListener
             config.setCapEnabled(true);
             config.addCapHandler(new SASLCapHandler(this.descriptor.getLogin(), this.descriptor.getSecretPassword().getPlainText()));
         } else {
-            String password = Util.fixEmpty(this.descriptor.getSecretPassword().getPlainText());
-            config.setServerPassword(password);
+            if (this.descriptor.getSecretPassword() != null) {
+                String password = Util.fixEmpty(this.descriptor.getSecretPassword().getPlainText());
+                config.setServerPassword(password);
+            }
         }
-        final String nickServPassword = Util.fixEmpty(this.descriptor.getSecretNickServPassword().getPlainText());
-        config.setNickservPassword(nickServPassword);
+
+        if (this.descriptor.getSecretNickServPassword() != null) {
+            final String nickServPassword = Util.fixEmpty(this.descriptor.getSecretNickServPassword().getPlainText());
+            config.setNickservPassword(nickServPassword);
+        }
 
 
         String socksHost = Util.fixEmpty(this.descriptor.getSocksHost());

--- a/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
+++ b/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
@@ -100,12 +100,12 @@ public class IRCConnection implements IMConnection, JoinListener, InviteListener
         if (this.descriptor.isSasl()) {
             LOGGER.info("Enabling SASL");
             config.setCapEnabled(true);
-            config.addCapHandler(new SASLCapHandler(this.descriptor.getLogin(), this.descriptor.getPassword()));
+            config.addCapHandler(new SASLCapHandler(this.descriptor.getLogin(), this.descriptor.getSecretPassword().getPlainText()));
         } else {
-            String password = Util.fixEmpty(this.descriptor.getPassword());
+            String password = Util.fixEmpty(this.descriptor.getSecretPassword().getPlainText());
             config.setServerPassword(password);
         }
-        final String nickServPassword = Util.fixEmpty(this.descriptor.getNickServPassword());
+        final String nickServPassword = Util.fixEmpty(this.descriptor.getSecretNickServPassword().getPlainText());
         config.setNickservPassword(nickServPassword);
 
 

--- a/src/main/resources/hudson/plugins/ircbot/IrcNotifyStep/config.jelly
+++ b/src/main/resources/hudson/plugins/ircbot/IrcNotifyStep/config.jelly
@@ -14,7 +14,7 @@
                   <input type="text" width="100%" style="text-align:left" name="irc_publisher.channel.name" value="${ch.name}" />
               </f:entry>
               <f:entry title="Password">
-                  <input type="password" width="100%" style="text-align:left" name="irc_publisher.channel.password" value="${ch.password}" />
+                  <input type="password" width="100%" style="text-align:left" name="irc_publisher.channel.secretPassword" value="${ch.password}" />
               </f:entry>
               <f:entry title="Notification only">
                   <f:checkbox name="irc_publisher.chat.notificationOnly" checked="${ch.notificationOnly}"/>

--- a/src/main/resources/hudson/plugins/ircbot/IrcNotifyStep/global.jelly
+++ b/src/main/resources/hudson/plugins/ircbot/IrcNotifyStep/global.jelly
@@ -31,7 +31,7 @@
                   <input type="text" width="100%" style="text-align:left" name="irc_publisher.channel.name" value="${ch.name}" />
               </f:entry>
               <f:entry title="Password">
-                  <input type="password" width="100%" style="text-align:left" name="irc_publisher.channel.password" value="${ch.password}" />
+                  <input type="password" width="100%" style="text-align:left" name="irc_publisher.channel.secretPassword" value="${ch.password}" />
               </f:entry>
               <f:entry title="Notification only">
                   <f:checkbox name="irc_publisher.chat.notificationOnly" checked="${ch.notificationOnly}"/>

--- a/src/main/resources/hudson/plugins/ircbot/IrcPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/ircbot/IrcPublisher/config.jelly
@@ -8,22 +8,24 @@
       <f:entry title="Channels"
               description="Channels to notify. Name and optional password. Check 'Notification only' if you want to disallow bot commands."
               help="/plugin/ircbot/help-instanceConfigChannels.html">
-          <f:repeatable name="irc_publisher.channels" var="ch" items="${instance.notificationTargets}">
-            <div width="100%">
-              <f:entry title="Name">
-                  <input type="text" width="100%" style="text-align:left" name="irc_publisher.channel.name" value="${ch.name}" />
-              </f:entry>
-              <f:entry title="Password">
-                  <input type="password" width="100%" style="text-align:left" name="irc_publisher.channel.password" value="${ch.password}" />
-              </f:entry>
-              <f:entry title="Notification only">
-                  <f:checkbox name="irc_publisher.chat.notificationOnly" checked="${ch.notificationOnly}"/>
-              </f:entry>
-              <f:entry>
-                  <div align="right"><f:repeatableDeleteButton /></div>
-              </f:entry>
-            </div>
-          </f:repeatable>
+        <f:repeatable var="ch" field="notificationTargets">
+          <div>
+            <f:entry title="Name">
+              <f:textbox field="name"/>
+            </f:entry>
+            <f:entry title="Password">
+              <f:password field="secretPassword"/>
+            </f:entry>
+            <f:entry title="Notification only">
+              <f:checkbox field="notificationOnly"/>
+            </f:entry>
+            <f:entry>
+              <div align="right">
+                <f:repeatableDeleteButton/>
+              </div>
+            </f:entry>
+          </div>
+        </f:repeatable>
       </f:entry>
 
      <super:notification-strategy/>

--- a/src/main/resources/hudson/plugins/ircbot/IrcPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/ircbot/IrcPublisher/config.jelly
@@ -19,6 +19,8 @@
             <f:entry title="Notification only">
               <f:checkbox field="notificationOnly"/>
             </f:entry>
+
+            <f:invisibleEntry><input type="hidden" name="class" value="hudson.plugins.im.GroupChatIMMessageTarget"/></f:invisibleEntry>
             <f:entry>
               <div align="right">
                 <f:repeatableDeleteButton/>

--- a/src/main/resources/hudson/plugins/ircbot/IrcPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/ircbot/IrcPublisher/global.jelly
@@ -12,15 +12,15 @@
         collide with other plugins. The 'descriptor' variable represents our descriptor
         object, so we use that to determine the initial value for this form.
       -->
-      <f:textbox name="irc_publisher.hostname" value="${descriptor.getHostname()}" />
+      <f:textbox field="hostname" />
     </f:entry>
     <f:entry title="Port"
       description="Port of the IRC server"
       help="/plugin/ircbot/help-globalConfigPort.html">
-      <f:textbox name="irc_publisher.port" value="${descriptor.getPort()}" />
+      <f:number field="port" />
     </f:entry>
     <f:entry title="SSL">
-      <f:checkbox name="irc_publisher.ssl" checked="${descriptor.ssl}"/>
+      <f:checkbox field="ssl"/>
     </f:entry>
     <f:entry title="Channels"
         description="Channels to join. Name and optional password. Check 'Notification only' if you want to disallow bot commands."
@@ -31,7 +31,7 @@
               <f:textbox field="name" />
             </f:entry>
             <f:entry title="Password">
-              <f:password field="password"/>
+              <f:password field="secretPassword"/>
             </f:entry>
             <f:entry title="Notification only">
                 <f:checkbox field="notificationOnly"/>
@@ -45,55 +45,55 @@
     <f:advanced>
         <f:entry title="Nickname"
           description="Nickname of the bot">
-          <f:textbox name="irc_publisher.nick" value="${descriptor.getNick()}" />
+          <f:textbox field="nick" />
         </f:entry>
         <f:entry title="Login"
           description="Login for the IRC server">
-          <f:textbox name="irc_publisher.login" value="${descriptor.getLogin()}" />
+          <f:textbox field="login" />
         </f:entry>
         <f:entry title="Password"
           description="Password for the IRC server">
-          <f:password name="irc_publisher.password" value="${descriptor.getPassword()}" />
+          <f:password field="secretPassword" />
         </f:entry>
         <f:entry title="SASL"
           description="Enable SASL for authentication">
-          <f:checkbox name="irc_publisher.sasl" checked="${descriptor.isSasl()}" />
+          <f:checkbox field="sasl" />
         </f:entry>
         <f:entry title="NickServ Password" description="On connection, try to identify with NickServ with this password" help="/plugin/ircbot/help-globalConfigNickServ.html">
-            <f:password name="irc_publisher.nickServPassword" value="${descriptor.nickServPassword}"/>
+            <f:password field="secretNickServPassword"/>
         </f:entry>
         <f:entry title="Command prefix"
           description="The prefix for the commands"
           help="/plugin/ircbot/help-globalConfigCommandPrefix.html">
-          <f:textbox name="irc_publisher.commandPrefix" value="${descriptor.getCommandPrefix()}" />
+          <f:textbox field="commandPrefix" />
         </f:entry>
         <f:entry title="Trust all SSL certificates" description="Ignore untrusted (e.g. self-signed) SSL certificates. Attention: this is insecure!"
           help="/plugin/ircbot/help-globalTrustAllCertificates.html">
-          <f:checkbox name="irc_publisher.ssl_trust_all_certificates" checked="${descriptor.trustAllCertificates}"/>
+          <f:checkbox field="sslTrustAllCertificates"/>
         </f:entry>
         <f:entry title="SOCKS proxy host" description="Proxy server hostname or IP (if applicable). Only supported without SSL.">
-          <f:textbox name="irc_publisher.socksHost" value="${descriptor.getSocksHost()}"/>
+          <f:textbox field="socksHost"/>
         </f:entry>
         <f:entry title="SOCKS proxy port" description="Proxy server port">
-          <f:textbox name="irc_publisher.socksPort" value="${descriptor.getSocksPort()}"/>
+          <f:number field="socksPort"/>
         </f:entry>
         <f:entry title="Disallow Private Chat" description="Disallow bot commands from private chat.">
-            <f:checkbox name="irc_publisher.disallowPrivateChat" checked="${descriptor.disallowPrivateChat}"/>
+            <f:checkbox field="disallowPrivateChat"/>
         </f:entry>
         <super:global-jenkinsLogin />
 
         <f:entry title="Notification charset" description="The character set to use for notifications">
-            <select name="irc_publisher.charset">
+            <select class="setting-input" name="irc_publisher.charset">
                <j:forEach var="cs" items="${descriptor.CHARSETS}">
                   <f:option selected="${instance.charset.toString()==cs}">${cs}</f:option>
                </j:forEach>
             </select>
         </f:entry>
         <f:entry title="Use /notice command" description="Use /notice command instead of /msg (default in ircbot &lt;= 2.0)">
-          <f:checkbox name="${descriptor.PARAMETERNAME_USE_NOTICE}" checked="${descriptor.useNotice}"/>
+          <f:checkbox field="useNotice"/>
         </f:entry>
         <f:entry title="Use colors" description="If checked, the bot will send colorized messages depending on the current and previous states of a job." help="/plugin/ircbot/help-globalConfigUseColors.html">
-          <f:checkbox name="${descriptor.PARAMETERNAME_USE_COLORS}" checked="${descriptor.useColors}"/>
+          <f:checkbox field="useColors"/>
         </f:entry>
     </f:advanced>
    </f:optionalBlock>

--- a/src/main/resources/hudson/plugins/ircbot/IrcPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/ircbot/IrcPublisher/global.jelly
@@ -36,6 +36,7 @@
             <f:entry title="Notification only">
                 <f:checkbox field="notificationOnly"/>
             </f:entry>
+            <f:invisibleEntry><input type="hidden" name="stapler-class" value="hudson.plugins.im.GroupChatIMMessageTarget"/></f:invisibleEntry>
             <f:entry>
                 <div align="right"><f:repeatableDeleteButton /></div>
             </f:entry>

--- a/src/main/resources/hudson/plugins/ircbot/IrcPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/ircbot/IrcPublisher/global.jelly
@@ -25,16 +25,16 @@
     <f:entry title="Channels"
         description="Channels to join. Name and optional password. Check 'Notification only' if you want to disallow bot commands."
         help="/plugin/ircbot/help-globalConfigChannels.html">
-     <f:repeatable name="irc_publisher.channels" var="ch" items="${descriptor.defaultTargets}">
-        <div width="100%">
+     <f:repeatable var="ch" field="defaultTargets">
+        <div>
             <f:entry title="Name">
-                <input type="text" width="100%" style="text-align:left" name="irc_publisher.channel.name" value="${ch.name}" />
+              <f:textbox field="name" />
             </f:entry>
             <f:entry title="Password">
-                <input type="password" width="100%" style="text-align:left" name="irc_publisher.channel.password" value="${ch.password}" />
+              <f:password field="password"/>
             </f:entry>
             <f:entry title="Notification only">
-                <f:checkbox name="irc_publisher.chat.notificationOnly" checked="${ch.notificationOnly}"/>
+                <f:checkbox field="notificationOnly"/>
             </f:entry>
             <f:entry>
                 <div align="right"><f:repeatableDeleteButton /></div>


### PR DESCRIPTION
TODO:

* ~interface hudson.plugins.im.IMMessageTarget is missing its descriptor~
* ~Apply same changes to job configuration~
* ~WARNING	hudson.Functions#getPasswordValue: <f:password/> form control in Jenkins/configure.jelly IrcPublisher/DescriptorImpl/global.jelly is not backed by hudson.util.Secret~
* ~verify passwords are working I think encrypted value is saved in string, probably solved by above~

Requires:

https://github.com/jenkinsci/instant-messaging-plugin/pull/44
and
https://github.com/jenkinsci/instant-messaging-plugin/pull/43

should be fully compatible

Also looks like it provides jcasc support, it's in the export, haven't verified if it fully works

Note: I'm not a user of this plugin, I've tested form binding interactively in a debugger and all looks good but I haven't configured it to talk to an actual IRC server.
