### PR TITLE
[JENKINS-64413] honor the default nickname limit (9 chars) to match IRC RFC 2812

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,11 @@ https://github.com/jenkinsci/ircbot-plugin/compare/ircbot-2.35...jenkinsci:ircbo
    need to change its value with the new plugin version running, please
    edit `$JENKINS_HOME/hudson.plugins.ircbot.IrcPublisher.xml` directly
    and restart Jenkins or gracefully reload its configuration.
+* Changed default IRC nickname for new deployments of the bot to `jenkins`
+  (from `jenkins-bot`) be in limits set by RFC 2812 (9 chars), and added
+  notes to the nickname editing fields in the UI (global config of the
+  server as a client to IRC; individual users' configs to link their IRC
+  accounts to Jenkins account)
 
 [[IRCPlugin-Version-2.35]]
 [[IRCPlugin-Version-2.34]]

--- a/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
+++ b/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
@@ -177,7 +177,8 @@ public class IrcPublisher extends IMPublisher {
 
         private boolean sasl;
 
-        String nick = "jenkins-bot";
+        /* Note that RFC 2812 limits by default to 9 chars; some servers enable more */
+        String nick = "jenkins";
 
         @Deprecated
         transient String nickServPassword = null;

--- a/src/main/resources/hudson/plugins/ircbot/IrcNotifyStep/global.jelly
+++ b/src/main/resources/hudson/plugins/ircbot/IrcNotifyStep/global.jelly
@@ -44,7 +44,7 @@
     </f:entry>
     <f:advanced>
         <f:entry title="Nickname"
-          description="Nickname of the bot">
+          description="Nickname of the bot (note that RFC 2812 limits by default to 9 chars; some servers enable more)">
           <f:textbox name="irc_publisher.nick" value="${descriptor.getNick()}" />
         </f:entry>
         <f:entry title="Login"

--- a/src/main/resources/hudson/plugins/ircbot/IrcPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/ircbot/IrcPublisher/global.jelly
@@ -45,7 +45,7 @@
     </f:entry>
     <f:advanced>
         <f:entry title="Nickname"
-          description="Nickname of the bot">
+          description="Nickname of the bot (note that RFC 2812 limits by default to 9 chars; some servers enable more)">
           <f:textbox field="nick" />
         </f:entry>
         <f:entry title="Login"

--- a/src/main/resources/hudson/plugins/ircbot/IrcUserProperty/config.jelly
+++ b/src/main/resources/hudson/plugins/ircbot/IrcUserProperty/config.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <f:entry title="IRC Nick"
-    description="Your IRC Nick">
+    description="Your IRC Nick (note that RFC 2812 limits by default to 9 chars; some servers enable more)">
     <input class="setting-input" name="irc.nick"
       type="text" value="${instance.nick}"/>
   </f:entry>


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-64413