### PR TITLE
Remove usages of Guava

### DIFF
--- a/src/main/java/hudson/plugins/ircbot/steps/IrcNotifyStep.java
+++ b/src/main/java/hudson/plugins/ircbot/steps/IrcNotifyStep.java
@@ -7,8 +7,6 @@ package hudson.plugins.ircbot.steps;
  *   https://github.com/jenkinsci/instant-messaging-plugin/pull/16
  */
 
-import com.google.common.collect.ImmutableSet;
-
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -23,6 +21,8 @@ import hudson.plugins.ircbot.v2.IRCMessageTargetConverter;
 import hudson.util.ListBoxModel;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -227,7 +227,9 @@ public class IrcNotifyStep extends Step {
 
         @Override
         public Set<? extends Class<?>> getRequiredContext() {
-            return ImmutableSet.of(FilePath.class, Run.class, Launcher.class, TaskListener.class);
+            Set<Class<?>> context = new HashSet<>();
+            Collections.addAll(context, FilePath.class, Run.class, Launcher.class, TaskListener.class);
+            return Collections.unmodifiableSet(context);
         }
 
         @Override

--- a/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
+++ b/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
@@ -1,7 +1,5 @@
 package hudson.plugins.ircbot.v2;
 
-import com.google.common.base.Function;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import hudson.Util;
@@ -25,7 +23,6 @@ import java.net.Proxy;
 import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -33,6 +30,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 import javax.net.SocketFactory;
 import javax.net.ssl.SSLSocketFactory;
@@ -46,8 +44,6 @@ import org.pircbotx.UtilSSLSocketFactory;
 import org.pircbotx.cap.SASLCapHandler;
 import org.pircbotx.hooks.ListenerAdapter;
 import org.pircbotx.hooks.events.ConnectEvent;
-
-import static com.google.common.collect.Collections2.transform;
 
 import static java.util.logging.Level.WARNING;
 
@@ -311,20 +307,16 @@ public class IRCConnection implements IMConnection, JoinListener, InviteListener
     }
 
     private boolean areWeConnectedToAllChannels() {
-        Set<String> groupChatNames = new HashSet<String>(transform(this.groupChats, new Function<IMMessageTarget, String>() {
-            @Override
-            public String apply(IMMessageTarget input) {
-                GroupChatIMMessageTarget group = (GroupChatIMMessageTarget) input;
-                return group.getName();
-            }
-        }));
+        Set<String> groupChatNames =
+                this.groupChats.stream()
+                        .map(GroupChatIMMessageTarget.class::cast)
+                        .map(GroupChatIMMessageTarget::getName)
+                        .collect(Collectors.toSet());
 
-        Set<String> connectedToChannels = new HashSet<String>(transform(this.pircConnection.getUserChannelDao().getAllChannels(), new Function<Channel, String>() {
-            @Override
-            public String apply(Channel input) {
-                return input.getName();
-            }
-        }));
+        Set<String> connectedToChannels =
+                this.pircConnection.getUserChannelDao().getAllChannels().stream()
+                        .map(Channel::getName)
+                        .collect(Collectors.toSet());
 
         return groupChatNames.equals(connectedToChannels);
     }


### PR DESCRIPTION
Slims down the dependency tree of this plugin by replacing any usages of Guava with native Java Platform functionality. CC @jimklimov 