### PR TITLE
[JENKINS-66556] Prepare IRC for core Guava upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,11 +75,6 @@ A build status publisher that notifies channels on a IRC server
                 </exclusion>
                 <!-- provided by jenkins core -->
                 <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-                <!-- provided by jenkins core -->
-                <exclusion>
                     <groupId>commons-codec</groupId>
                     <artifactId>commons-codec</artifactId>
                 </exclusion>
@@ -189,6 +184,7 @@ A build status publisher that notifies channels on a IRC server
                     <loggers>
                         <hudson.plugins.im>FINE</hudson.plugins.im>
                     </loggers>
+                    <maskClasses>com.google.common.</maskClasses>
                     <compatibleSinceVersion>2.0</compatibleSinceVersion>
                 </configuration>
             </plugin>


### PR DESCRIPTION
### Problem

While testing this plugin against a pre-release version of Jenkins with Guava upgraded to the latest version, I received this error:

```
2021-10-02 21:13:49.887+0000 [id=107]   SEVERE  h.i.i.InstallUncaughtExceptionHandler$DefaultUncaughtExceptionHandler#uncaughtException: A thread (IRC Bot/107) died unexpectedly due to an uncaught exception, this may leave your Jenkins in a bad way and is usually indicative of a bug in the code.
java.lang.NoSuchFieldError: WHITESPACE
        at org.pircbotx.Utils.tokenizeLine(Utils.java:105)
        at org.pircbotx.InputParser.handleLine(InputParser.java:284)
        at org.pircbotx.PircBotX.startLineProcessing(PircBotX.java:275)
        at org.pircbotx.PircBotX.connect(PircBotX.java:236)
        at org.pircbotx.PircBotX.startBot(PircBotX.java:151)
        at hudson.plugins.ircbot.v2.IRCConnection$2.run(IRCConnection.java:217)
```

### Evaluation

This plugin depends on PircBotX 2.0.1, which depends on Guava 11.0.1. This plugin currently excludes the Guava dependency from the plugin JPI, which means this plugin uses the Guava dependency from core. On current versions of Jenkins core, Guava is at version 11.0.1, so this plugin works. But when Guava is upgraded in core, PircBotX will attempt to use the `WHITESPACE` field, which has been removed from the most recent version of Guava. Thus this plugin would break if core's version of Guava was upgraded.

### Solution

Make this plugin compatible with cores that have both the old and new versions of Guava by removing the exclusion, thereby bundling the version of Guava that PircBotX depends on in this plugin's JPI. Since core also ships a version of Guava, this would be unused by default without also masking the version of Guava shipped by core. We do so by adding a `maskClasses` section, which [blocks Guava packages from the parent loader](https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/#pluginfirstclassloader-and-its-discontents) and allows it to be used from the plugin's JPI. This is the same approach that is taken by the Artifact Manager on S3 plugin. With this approach in place, the plugin works regardless of the version of Guava shipped by core.

### Testing Done

- Reproduced the original problem against a local build of Jenkins core with the most recent version of Guava. Could not reproduce the problem after this change.
- Also tested this change against tip-of-trunk Jenkins core with Guava 11.0.1. There were no regressions.

CC @jimklimov