### PR TITLE
pom.xml: bump to newer interim revision of pircbotx-v2.3-gb1b48bf-9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,12 @@
         <dependency>
             <groupId>com.github.pircbotx</groupId>
             <artifactId>pircbotx</artifactId>
-            <version>-2.1-g479835f-165</version>
+            <!-- https://jitpack.io/#pircbotx/pircbotx => Branches => master-SNAPSHOT
+                 => https://jitpack.io/com/github/pircbotx/pircbotx/-v2.3-gb1b48bf-9/build.log
+	         Using recent previews until 2.4 which should fix packaging
+		 NOTE the leading minus in temporary-availability version!
+	    -->
+            <version>-v2.3-gb1b48bf-9</version>
             <scope>compile</scope>
             <exclusions>
                 <!-- provides an ancient version, junit plugin is pulling in a more recent one -->


### PR DESCRIPTION
Older one disappeared from published storage