### PR TITLE
pom.xml: disable maven-enforcer-plugin hacks from #164…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,7 @@
                  See centralized config in
                  https://github.com/jenkinsci/plugin-pom/blob/ec78ae1af0b5365d8d17121f3d5be720acb87f13/pom.xml#L550-L570
               -->
+<!--
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <executions>
@@ -255,6 +256,7 @@
                     </execution>
                 </executions>
             </plugin>
+-->
 
         </plugins>
     </build>


### PR DESCRIPTION
… only needed for use of non-release versions of pircbotx

Further follow-up to the mess introduced by #164, and to #190 which switched the tracks back to use of proper pircbotx releases. Hopefully this does not begin to fail the CI builds again :)