### PR TITLE
Use Artifact Caching Proxy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ buildPlugin(
  // See also https://github.com/jenkins-infra/pipeline-library/pull/577
  //          https://github.com/jenkins-infra/pipeline-library/pull/522
  //          https://github.com/jenkins-infra/pipeline-library/pull/635
- useArtifactCachingProxy: false,
+ useArtifactCachingProxy: true,
  configurations: [
   // Test the common case (i.e., a recent LTS release) on both Linux and Windows.
   [ platform: 'linux', jdk: '11', jenkins: '2.375.1' ],

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,12 +4,6 @@
  */
 buildPlugin(
  useContainerAgent: true,
- // Opt-in to the Artifact Caching Proxy? (maybe to be removed when it will be opt-out)
- // See https://github.com/jenkins-infra/helpdesk/issues/2752 for more details and updates.
- // See also https://github.com/jenkins-infra/pipeline-library/pull/577
- //          https://github.com/jenkins-infra/pipeline-library/pull/522
- //          https://github.com/jenkins-infra/pipeline-library/pull/635
- useArtifactCachingProxy: true,
  configurations: [
   // Test the common case (i.e., a recent LTS release) on both Linux and Windows.
   [ platform: 'linux', jdk: '11', jenkins: '2.375.1' ],


### PR DESCRIPTION
This PR reactivates the use of artifact caching proxy as the `jitpack.io` 3rd party Maven repository has been added to ci.jenkins.io mirror settings exceptions in https://github.com/jenkins-infra/jenkins-infra/pull/2895.

Ref: https://github.com/jenkins-infra/helpdesk/issues/3591

### Testing done

Replayed a PR build with this option set to true: https://ci.jenkins.io/job/Plugins/job/ircbot-plugin/job/PR-195/2/console
>  Finished: SUCCESS

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
