### PR TITLE
Upgrade the parent to upgrade SpotBugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.7</version>
+        <version>5.14</version>
         <relativePath />
     </parent>
 
@@ -261,8 +261,6 @@
                 </executions>
             </plugin>
 -->
-
         </plugins>
     </build>
-
 </project>

--- a/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
+++ b/src/main/java/hudson/plugins/ircbot/v2/IRCConnection.java
@@ -75,7 +75,7 @@ public class IRCConnection implements IMConnection, JoinListener, InviteListener
     private final Map<String, Bot> privateChats = new HashMap<String, Bot>();
 
 
-    @SuppressFBWarnings(value={"UR_UNINIT_READ", "MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR"},
+    @SuppressFBWarnings(value={"UR_UNINIT_READ"},
         justification="UR_UNINIT_READ: TODO: this is probably a genuine problem but I don't know why; MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR: Need ecosystem change to separate IRCConnection construction from PircListener connection")
     public IRCConnection(DescriptorImpl descriptor, AuthenticationHolder authentication) {
         Builder config = new Configuration.Builder();


### PR DESCRIPTION
This is in relation to https://github.com/spotbugs/spotbugs/issues/3429
It looks like the bugs are no longer spotted by SpotBugs and when upgrading the suppressions become useless.
At the same time SpotBugs now reports useless suppressions, so they need to be removed when upgrading.