### PR TITLE
Migrate from Commons Lang 2 to Commons Lang 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <spotbugs.effort>Max</spotbugs.effort>
         <spotbugs.threshold>Low</spotbugs.threshold>
         <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
+        <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
     </properties>
 
     <dependencyManagement>
@@ -66,6 +67,10 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-lang3-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.jvnet.hudson.plugins</groupId>
             <artifactId>instant-messaging</artifactId>

--- a/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
+++ b/src/main/java/hudson/plugins/ircbot/IrcPublisher.java
@@ -38,7 +38,6 @@ import java.util.logging.Logger;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
-import org.apache.commons.lang.StringUtils;
 
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -659,16 +658,16 @@ public class IrcPublisher extends IMPublisher {
                 this.messageRate = getMessageRateFromSystemProperty();
             }
 
-            if (StringUtils.isNotBlank(this.password)) {
+            if ((this.password != null && !this.password.isBlank())) {
                 this.secretPassword = Secret.fromString(Scrambler.descramble(this.password));
                 this.password = null;
             }
-            if (StringUtils.isNotBlank(this.nickServPassword)) {
+            if ((this.nickServPassword != null && !this.nickServPassword.isBlank())) {
                 this.secretNickServPassword = Secret.fromString(Scrambler.descramble(this.nickServPassword));
                 this.nickServPassword = null;
             }
 
-            if (StringUtils.isNotBlank(this.hudsonLogin)) {
+            if ((this.hudsonLogin != null && !this.hudsonLogin.isBlank())) {
                 this.jenkinsLogin = this.hudsonLogin;
                 this.hudsonLogin = null;
             }

--- a/src/main/java/hudson/plugins/ircbot/steps/IrcNotifyStep.java
+++ b/src/main/java/hudson/plugins/ircbot/steps/IrcNotifyStep.java
@@ -29,7 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;


### PR DESCRIPTION
Migrate from deprecated/EOL Commons Lang 2 to Commons Lang 3.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

## What's changed

- `IrcPublisher`: the `StringUtils.isNotBlank` checks become plain null plus `isBlank()` checks.
- `IrcNotifyStep`: `StringUtils.split(targets, TARGET_SEPARATOR_CHAR)` moves to
  `org.apache.commons.lang3` rather than `String.split` — Commons Lang's `split` takes separator
  characters and drops empty tokens, which `String.split` (a regex) does not reproduce.
  `io.jenkins.plugins:commons-lang3-api` is declared for it.
- Enabled the `ban-commons-lang-2` enforcer rule to prevent regressions.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.

The `ban-commons-lang-2` enforcer rule is enabled in this PR, so the build fails if an
`org.apache.commons.lang.*` import comes back.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact @timja.
